### PR TITLE
Packaging with setup.cfg

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,10 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Dependencies
-        run: pip install mypy && pip install --no-deps .
+        run: |
+          pip install -U pip
+          sudo apt install libgirepository1.0-dev
+          pip install '.[dev]'
 
       - name: Run mypy
         run: mypy examples

--- a/examples/gtk.py
+++ b/examples/gtk.py
@@ -1,4 +1,11 @@
+import gi
 from gi.repository import Gtk, Gdk, GdkPixbuf, Gio, Atk, Gst
+
+gi.__version__
+
+gi.require_version
+
+gi.require_versions
 
 Gtk.Button
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["wheel", "setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,36 @@
+[metadata]
+name = PyGObject-stubs
+version = 0.0.7
+description = Typing stubs for PyGobject
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = GNU Lesser General Public License v2.1
+author = Christoph Reiter
+author_email = reiter.christoph@gmail.com
+url = https://github.com/pygobject/pygobject-stubs
+classifiers =
+    Intended Audience :: Developers
+    Programming Language :: Python
+    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
+    Operating System :: OS Independent
+
+[options]
+packages =
+    gi-stubs
+install_requires =
+    PyGObject
+include_package_data = True
+
+[options.package_data]
+* = *.pyi, */*.pyi
+
+[options.extras_require]
+dev =
+    mypy
+    flake8
+    flake8-pyi
+    setuptools
+    wheel
+
 [flake8]
-ignore=W391,E302,E704,E701,E305
+ignore = W391,E302,E704,E701,E305

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,3 @@
 from setuptools import setup
 
-with open('README.md', 'r', encoding='utf-8') as fh:
-    long_description = fh.read()
-
-setup(
-    name="PyGObject-stubs",
-    description="Typing stubs for PyGobject",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/pygobject/pygobject-stubs",
-    author="Christoph Reiter",
-    author_email="reiter.christoph@gmail.com",
-    version="0.0.7",
-    classifiers=[
-        'Intended Audience :: Developers',
-        "Programming Language :: Python",
-        "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
-        "Operating System :: OS Independent",
-    ],
-    package_data={"gi-stubs": ["*.pyi", "*/*.pyi"]},
-    packages=["gi-stubs"],
-    install_requires=["PyGObject"],
-)
+setup()


### PR DESCRIPTION
I have moved packaging information from setup.py to setup.cfg and added pyproject.toml for supporting both `pip install -e .` and `pip install .`.

Also I have added dev dependencies as extras_require in setup.cfg. This enables to install them with `pip install '.[dev]'`.