### PR TITLE
Exclude PyGObject from install_requires

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,33 @@
 
 ## Generating base stubs for module
 
-Check the `tools` folder
+You can generate stubs with `tools/generate.py`.
 
-Usage: `python generate.py -h`
+Usage:
+
+```shellsession
+$ python tools/generate.py -h
+usage: generate.py [-h] module version
+
+Generate module stubs Usage: generate.py Gdk 3.0 > Gdk.py
+
+positional arguments:
+  module      Gdk, Gtk, ...
+  version     3.0, 4.0, ...
+
+options:
+  -h, --help  show this help message and exit
+```
+
+To generate `Gdk` stubs based on PyGObject 3.0 and save to `Gdk.py`:
+
+```bash
+pip install mypy PyGObject
+python generate.py Gdk 3.0 > Gdk.py
+```
+
+## Testing generated stubs are correctly typed
+
+```bash
+mypy examples
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,10 +30,7 @@ dev =
     mypy
     flake8
     flake8-pyi
-    setuptools
-    wheel
 generate =
-    mypy
     PyGObject
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,20 +17,24 @@ classifiers =
 [options]
 packages =
     gi-stubs
-install_requires =
-    PyGObject
 include_package_data = True
 
 [options.package_data]
 * = *.pyi, */*.pyi
 
 [options.extras_require]
+all =
+    %(dev)s
+    %(generate)s
 dev =
     mypy
     flake8
     flake8-pyi
     setuptools
     wheel
+generate =
+    mypy
+    PyGObject
 
 [flake8]
 ignore = W391,E302,E704,E701,E305


### PR DESCRIPTION
Motivation: https://github.com/pre-commit-ci/issues/issues/126

I think stub-only packages should not depend on original packages. So I have moved PyGObject from install_requires into `generate` extras.