### PR TITLE
imprv RFC: Gtk3.Dialog: add some missing features to ctor

### DIFF
--- a/src/gi-stubs/repository/_Gtk3.pyi
+++ b/src/gi-stubs/repository/_Gtk3.pyi
@@ -1791,6 +1791,7 @@ class Dialog(Window):
 
     def __init__(
         self,
+        title: Optional[str] = None,
         *,
         # Window Properties
         accept_focus: bool = True,
@@ -1820,7 +1821,7 @@ class Dialog(Window):
         skip_pager_hint: bool = False,
         skip_taskbar_hint: bool = False,
         startup_id: Optional[str] = None,
-        title: Optional[str] = None,
+        #title: Optional[str] = None,
         transient_for: Optional[Window] = None,
         type: WindowType = WindowType.TOPLEVEL,
         type_hint: Gdk.WindowTypeHint = Gdk.WindowTypeHint.NORMAL,
@@ -1828,6 +1829,8 @@ class Dialog(Window):
         window_position: WindowPosition = WindowPosition.NONE,
         # Dialog Properties
         use_header_bar: bool = False,
+        # new_with_buttons?
+        buttons: list[Any] = [],
     ) -> None: ...
     def add_action_widget(*args, **kwargs): ...
     def add_button(self, buton_text: str, response_id: int) -> Widget: ...


### PR DESCRIPTION
This is an attempt to add to the Dialog ctor a couple of things that always worked for me in Gtk3: title as positional parameter, and buttons list (which spares a separate call to `.add_buttons()`.  I admit I don't see them documented anywhere, and have no clue why - so maybe there are reasons not to include them, I'd be happy to learn :)
