### PR TITLE
new: Migrate stubs generator to GIRepository 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build
 dist
 *.egg-info
 *.sublime-*
+*.vscode
 *.venv
 
 src/gi-stubs/repository/Gdk.pyi


### PR DESCRIPTION
Migration guide: https://docs.gtk.org/girepository/migrating-gi.html

This requires pygobject > 3.50 to be installed.

Enums and Flags now use Python's enum types, see [link](https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/394#e9c67f4b54ead859314ace8639f380d56bf5a7e2)

GObject.GEnum -> enum.IntEnum
GObject.GFlags -> enum.IntFlag

Results using the new GIRepository 3.0 generator compared to using the GIRepository 2.0 generator:
- Spelling: no changes (whitespace only)
- Adw: no changes (whitespace only)
- Gdk 4: no changes (whitespace only)
- Gtk 4: no changes (whitespace only)
- GLib/GObject: a specific method has changes in its signature: MainContext.query, which is [an override](https://gitlab.gnome.org/GNOME/pygobject/-/blob/main/gi/overrides/GLib.py?ref_type=heads#L571) which we need to add manually

Closes #213
