### PR TITLE
imprv: class generation, props typing, and `__init__` arguments

### DIFF
--- a/src/gi-stubs/repository/Adw.pyi
+++ b/src/gi-stubs/repository/Adw.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -150,6 +151,7 @@ class AboutDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         application_icon: str
         application_name: str
@@ -171,51 +173,6 @@ class AboutDialog(Dialog):
         translator_credits: str
         version: str
         website: str
-        can_close: bool
-        child: _Gtk4.Widget | None
-        content_height: int
-        content_width: int
-        current_breakpoint: Breakpoint | None
-        default_widget: _Gtk4.Widget | None
-        focus_widget: _Gtk4.Widget | None
-        follows_content_size: bool
-        presentation_mode: DialogPresentationMode
-        title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -243,6 +200,7 @@ class AboutDialog(Dialog):
         translator_credits: str = ...,
         version: str = ...,
         website: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_close: bool = ...,
         child: _Gtk4.Widget | None = ...,
         content_height: int = ...,
@@ -282,7 +240,6 @@ class AboutDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_acknowledgement_section(
         self, name: str | None, people: Sequence[str]
@@ -489,6 +446,7 @@ class AboutWindow(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         application_icon: str
         application_name: str
@@ -510,73 +468,7 @@ class AboutWindow(Window):
         translator_credits: str
         version: str
         website: str
-        adaptive_preview: bool
-        content: _Gtk4.Widget | None
-        current_breakpoint: Breakpoint | None
-        dialogs: Gio.ListModel
-        visible_dialog: Dialog | None
-        application: _Gtk4.Application | None
-        child: _Gtk4.Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: _Gtk4.Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: _Gtk4.Widget | None
-        fullscreened: bool
-        gravity: _Gtk4.WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: _Gtk4.Widget | None
-        transient_for: _Gtk4.Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -603,6 +495,7 @@ class AboutWindow(Window):
         translator_credits: str = ...,
         version: str = ...,
         website: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         adaptive_preview: bool = ...,
         content: _Gtk4.Widget | None = ...,
         application: _Gtk4.Application | None = ...,
@@ -659,7 +552,6 @@ class AboutWindow(Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_acknowledgement_section(
         self, name: str | None, people: Sequence[str]
@@ -822,6 +714,7 @@ class ActionRow(PreferencesRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(PreferencesRow.Props):
         activatable_widget: _Gtk4.Widget | None
         icon_name: str | None
@@ -829,48 +722,6 @@ class ActionRow(PreferencesRow):
         subtitle_lines: int
         subtitle_selectable: bool
         title_lines: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -888,6 +739,9 @@ class ActionRow(PreferencesRow):
         subtitle_lines: int = ...,
         subtitle_selectable: bool = ...,
         title_lines: int = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         title: str = ...,
         title_selectable: bool = ...,
         use_markup: bool = ...,
@@ -925,9 +779,6 @@ class ActionRow(PreferencesRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def activate(self) -> None: ...
     def add_prefix(self, widget: _Gtk4.Widget) -> None: ...
@@ -1059,6 +910,7 @@ class AlertDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         body: str
         body_use_markup: bool
@@ -1068,51 +920,6 @@ class AlertDialog(Dialog):
         heading: str | None
         heading_use_markup: bool
         prefer_wide_layout: bool
-        can_close: bool
-        child: _Gtk4.Widget | None
-        content_height: int
-        content_width: int
-        current_breakpoint: Breakpoint | None
-        default_widget: _Gtk4.Widget | None
-        focus_widget: _Gtk4.Widget | None
-        follows_content_size: bool
-        presentation_mode: DialogPresentationMode
-        title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -1130,6 +937,7 @@ class AlertDialog(Dialog):
         heading: str | None = ...,
         heading_use_markup: bool = ...,
         prefer_wide_layout: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_close: bool = ...,
         child: _Gtk4.Widget | None = ...,
         content_height: int = ...,
@@ -1169,7 +977,6 @@ class AlertDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_response(self, id: str, label: str) -> None: ...
     def choose(
@@ -1250,12 +1057,16 @@ class Animation(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         follow_enable_animations_setting: bool
-        state: AnimationState
+        @property
+        def state(self) -> AnimationState: ...
         target: AnimationTarget
-        value: float
-        widget: _Gtk4.Widget
+        @property
+        def value(self) -> float: ...
+        @property
+        def widget(self) -> _Gtk4.Widget: ...
 
     @property
     def props(self) -> Props: ...
@@ -1282,7 +1093,21 @@ class Animation(GObject.Object):
     def skip(self) -> None: ...
 
 class AnimationClass(_gi.Struct): ...
-class AnimationTarget(GObject.Object): ...
+
+class AnimationTarget(GObject.Object):
+    """
+    :Constructors:
+
+    ::
+
+        AnimationTarget(**properties)
+
+    Object AdwAnimationTarget
+
+    Signals from GObject:
+      notify (GParam)
+    """
+
 class AnimationTargetClass(_gi.Struct): ...
 
 class Application(_Gtk4.Application):
@@ -1351,21 +1176,10 @@ class Application(_Gtk4.Application):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Application.Props):
-        style_manager: StyleManager
-        active_window: _Gtk4.Window | None
-        menubar: Gio.MenuModel | None
-        register_session: bool
-        screensaver_active: bool
-        application_id: str | None
-        flags: Gio.ApplicationFlags
-        inactivity_timeout: int
-        is_busy: bool
-        is_registered: bool
-        is_remote: bool
-        resource_base_path: str | None
-        version: str | None
-        action_group: Gio.ActionGroup | None
+        @property
+        def style_manager(self) -> StyleManager: ...
 
     @property
     def props(self) -> Props: ...
@@ -1525,75 +1339,17 @@ class ApplicationWindow(_Gtk4.ApplicationWindow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.ApplicationWindow.Props):
         adaptive_preview: bool
         content: _Gtk4.Widget | None
-        current_breakpoint: Breakpoint | None
-        dialogs: Gio.ListModel
-        visible_dialog: Dialog | None
-        show_menubar: bool
-        application: _Gtk4.Application | None
-        child: _Gtk4.Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: _Gtk4.Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: _Gtk4.Widget | None
-        fullscreened: bool
-        gravity: _Gtk4.WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: _Gtk4.Widget | None
-        transient_for: _Gtk4.Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def current_breakpoint(self) -> Breakpoint | None: ...
+        @property
+        def dialogs(self) -> Gio.ListModel: ...
+        @property
+        def visible_dialog(self) -> Dialog | None: ...
         accessible_role: _Gtk4.AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -1604,6 +1360,7 @@ class ApplicationWindow(_Gtk4.ApplicationWindow):
         *,
         adaptive_preview: bool = ...,
         content: _Gtk4.Widget | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         show_menubar: bool = ...,
         application: _Gtk4.Application | None = ...,
         child: _Gtk4.Widget | None = ...,
@@ -1659,7 +1416,6 @@ class ApplicationWindow(_Gtk4.ApplicationWindow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_breakpoint(self, breakpoint: Breakpoint) -> None: ...
     def get_adaptive_preview(self) -> bool: ...
@@ -1758,47 +1514,13 @@ class Avatar(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         custom_image: _Gdk4.Paintable | None
         icon_name: str | None
         show_initials: bool
         size: int
         text: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -1811,6 +1533,7 @@ class Avatar(_Gtk4.Widget):
         show_initials: bool = ...,
         size: int = ...,
         text: str | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -1841,7 +1564,6 @@ class Avatar(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def draw_to_texture(self, scale_factor: int) -> _Gdk4.Texture: ...
     def get_custom_image(self) -> _Gdk4.Paintable | None: ...
@@ -1944,47 +1666,13 @@ class Banner(_Gtk4.Widget, _Gtk4.Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         button_label: str | None
         button_style: BannerButtonStyle
         revealed: bool
         title: str
         use_markup: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -1999,6 +1687,9 @@ class Banner(_Gtk4.Widget, _Gtk4.Actionable):
         revealed: bool = ...,
         title: str = ...,
         use_markup: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -2029,9 +1720,6 @@ class Banner(_Gtk4.Widget, _Gtk4.Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_button_label(self) -> str | None: ...
     def get_button_style(self) -> BannerButtonStyle: ...
@@ -2126,43 +1814,9 @@ class Bin(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -2173,6 +1827,7 @@ class Bin(_Gtk4.Widget):
         self,
         *,
         child: _Gtk4.Widget | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -2203,7 +1858,6 @@ class Bin(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
     @classmethod
@@ -2305,10 +1959,12 @@ class BottomSheet(_Gtk4.Widget, Swipeable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         align: float
         bottom_bar: _Gtk4.Widget | None
-        bottom_bar_height: int
+        @property
+        def bottom_bar_height(self) -> int: ...
         can_close: bool
         can_open: bool
         content: _Gtk4.Widget | None
@@ -2317,43 +1973,9 @@ class BottomSheet(_Gtk4.Widget, Swipeable):
         open: bool
         reveal_bottom_bar: bool
         sheet: _Gtk4.Widget | None
-        sheet_height: int
+        @property
+        def sheet_height(self) -> int: ...
         show_drag_handle: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -2372,6 +1994,7 @@ class BottomSheet(_Gtk4.Widget, Swipeable):
         reveal_bottom_bar: bool = ...,
         sheet: _Gtk4.Widget | None = ...,
         show_drag_handle: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -2402,7 +2025,6 @@ class BottomSheet(_Gtk4.Widget, Swipeable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_align(self) -> float: ...
     def get_bottom_bar(self) -> _Gtk4.Widget | None: ...
@@ -2463,6 +2085,7 @@ class Breakpoint(GObject.Object, _Gtk4.Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         condition: BreakpointCondition | None
 
@@ -2553,44 +2176,11 @@ class BreakpointBin(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
-        current_breakpoint: Breakpoint | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def current_breakpoint(self) -> Breakpoint | None: ...
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -2601,6 +2191,7 @@ class BreakpointBin(_Gtk4.Widget):
         self,
         *,
         child: _Gtk4.Widget | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -2631,7 +2222,6 @@ class BreakpointBin(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_breakpoint(self, breakpoint: Breakpoint) -> None: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
@@ -2770,46 +2360,12 @@ class ButtonContent(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         can_shrink: bool
         icon_name: str
         label: str
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -2821,6 +2377,7 @@ class ButtonContent(_Gtk4.Widget):
         icon_name: str = ...,
         label: str = ...,
         use_underline: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -2851,7 +2408,6 @@ class ButtonContent(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_can_shrink(self) -> bool: ...
     def get_icon_name(self) -> str: ...
@@ -2962,51 +2518,10 @@ class ButtonRow(PreferencesRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(PreferencesRow.Props):
         end_icon_name: str | None
         start_icon_name: str | None
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -3018,6 +2533,9 @@ class ButtonRow(PreferencesRow):
         *,
         end_icon_name: str | None = ...,
         start_icon_name: str | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         title: str = ...,
         title_selectable: bool = ...,
         use_markup: bool = ...,
@@ -3055,9 +2573,6 @@ class ButtonRow(PreferencesRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_end_icon_name(self) -> str | None: ...
     def get_start_icon_name(self) -> str | None: ...
@@ -3178,51 +2693,19 @@ class Carousel(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         allow_long_swipes: bool
         allow_mouse_drag: bool
         allow_scroll_wheel: bool
         interactive: bool
-        n_pages: int
-        position: float
+        @property
+        def n_pages(self) -> int: ...
+        @property
+        def position(self) -> float: ...
         reveal_duration: int
         scroll_params: SpringParams
         spacing: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -3238,6 +2721,8 @@ class Carousel(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         reveal_duration: int = ...,
         scroll_params: SpringParams = ...,
         spacing: int = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -3268,8 +2753,6 @@ class Carousel(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def append(self, child: _Gtk4.Widget) -> None: ...
     def get_allow_long_swipes(self) -> bool: ...
@@ -3377,43 +2860,9 @@ class CarouselIndicatorDots(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         carousel: Carousel | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -3423,6 +2872,8 @@ class CarouselIndicatorDots(_Gtk4.Widget, _Gtk4.Orientable):
         self,
         *,
         carousel: Carousel | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -3453,8 +2904,6 @@ class CarouselIndicatorDots(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def get_carousel(self) -> Carousel | None: ...
     @classmethod
@@ -3541,43 +2990,9 @@ class CarouselIndicatorLines(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         carousel: Carousel | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -3587,6 +3002,8 @@ class CarouselIndicatorLines(_Gtk4.Widget, _Gtk4.Orientable):
         self,
         *,
         carousel: Carousel | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -3617,8 +3034,6 @@ class CarouselIndicatorLines(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def get_carousel(self) -> Carousel | None: ...
     @classmethod
@@ -3708,46 +3123,12 @@ class Clamp(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
         maximum_size: int
         tightening_threshold: int
         unit: LengthUnit
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -3760,6 +3141,8 @@ class Clamp(_Gtk4.Widget, _Gtk4.Orientable):
         maximum_size: int = ...,
         tightening_threshold: int = ...,
         unit: LengthUnit = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -3790,8 +3173,6 @@ class Clamp(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
     def get_maximum_size(self) -> int: ...
@@ -3834,6 +3215,7 @@ class ClampLayout(_Gtk4.LayoutManager, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.LayoutManager.Props):
         maximum_size: int
         tightening_threshold: int
@@ -3942,46 +3324,12 @@ class ClampScrollable(_Gtk4.Widget, _Gtk4.Orientable, _Gtk4.Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
         maximum_size: int
         tightening_threshold: int
         unit: LengthUnit
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
         hadjustment: _Gtk4.Adjustment | None
@@ -3998,6 +3346,12 @@ class ClampScrollable(_Gtk4.Widget, _Gtk4.Orientable, _Gtk4.Scrollable):
         maximum_size: int = ...,
         tightening_threshold: int = ...,
         unit: LengthUnit = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
+        hadjustment: _Gtk4.Adjustment | None = ...,
+        hscroll_policy: _Gtk4.ScrollablePolicy = ...,
+        vadjustment: _Gtk4.Adjustment | None = ...,
+        vscroll_policy: _Gtk4.ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -4028,12 +3382,6 @@ class ClampScrollable(_Gtk4.Widget, _Gtk4.Orientable, _Gtk4.Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
-        hadjustment: _Gtk4.Adjustment | None = ...,
-        hscroll_policy: _Gtk4.ScrollablePolicy = ...,
-        vadjustment: _Gtk4.Adjustment | None = ...,
-        vscroll_policy: _Gtk4.ScrollablePolicy = ...,
     ) -> None: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
     def get_maximum_size(self) -> int: ...
@@ -4161,6 +3509,7 @@ class ComboRow(ActionRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ActionRow.Props):
         enable_search: bool
         expression: _Gtk4.Expression | None
@@ -4170,56 +3519,9 @@ class ComboRow(ActionRow):
         model: Gio.ListModel | None
         search_match_mode: _Gtk4.StringFilterMatchMode
         selected: int
-        selected_item: GObject.Object | None
+        @property
+        def selected_item(self) -> GObject.Object | None: ...
         use_subtitle: bool
-        activatable_widget: _Gtk4.Widget | None
-        icon_name: str | None
-        subtitle: str | None
-        subtitle_lines: int
-        subtitle_selectable: bool
-        title_lines: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -4240,6 +3542,9 @@ class ComboRow(ActionRow):
         search_match_mode: _Gtk4.StringFilterMatchMode = ...,
         selected: int = ...,
         use_subtitle: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         activatable_widget: _Gtk4.Widget | None = ...,
         icon_name: str | None = ...,
         subtitle: str = ...,
@@ -4283,9 +3588,6 @@ class ComboRow(ActionRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_enable_search(self) -> bool: ...
     def get_expression(self) -> _Gtk4.Expression | None: ...
@@ -4410,52 +3712,19 @@ class Dialog(_Gtk4.Widget, _Gtk4.ShortcutManager):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         can_close: bool
         child: _Gtk4.Widget | None
         content_height: int
         content_width: int
-        current_breakpoint: Breakpoint | None
+        @property
+        def current_breakpoint(self) -> Breakpoint | None: ...
         default_widget: _Gtk4.Widget | None
         focus_widget: _Gtk4.Widget | None
         follows_content_size: bool
         presentation_mode: DialogPresentationMode
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -4474,6 +3743,7 @@ class Dialog(_Gtk4.Widget, _Gtk4.ShortcutManager):
         follows_content_size: bool = ...,
         presentation_mode: DialogPresentationMode = ...,
         title: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -4504,7 +3774,6 @@ class Dialog(_Gtk4.Widget, _Gtk4.ShortcutManager):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_breakpoint(self, breakpoint: Breakpoint) -> None: ...
     def close(self) -> bool: ...
@@ -4654,6 +3923,7 @@ class EntryRow(PreferencesRow, _Gtk4.Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(PreferencesRow.Props):
         activates_default: bool
         attributes: Pango.AttrList | None
@@ -4662,57 +3932,18 @@ class EntryRow(PreferencesRow, _Gtk4.Editable):
         input_purpose: _Gtk4.InputPurpose
         max_length: int
         show_apply_button: bool
-        text_length: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def text_length(self) -> int: ...
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -4731,6 +3962,15 @@ class EntryRow(PreferencesRow, _Gtk4.Editable):
         input_purpose: _Gtk4.InputPurpose = ...,
         max_length: int = ...,
         show_apply_button: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         title: str = ...,
         title_selectable: bool = ...,
         use_markup: bool = ...,
@@ -4768,15 +4008,6 @@ class EntryRow(PreferencesRow, _Gtk4.Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def add_prefix(self, widget: _Gtk4.Widget) -> None: ...
     def add_suffix(self, widget: _Gtk4.Widget) -> None: ...
@@ -4829,10 +4060,14 @@ class EnumListItem(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        name: str
-        nick: str
-        value: int
+        @property
+        def name(self) -> str: ...
+        @property
+        def nick(self) -> str: ...
+        @property
+        def value(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -4871,8 +4106,10 @@ class EnumListModel(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        enum_type: type[Any]
+        @property
+        def enum_type(self) -> type[Any]: ...
 
     @property
     def props(self) -> Props: ...
@@ -4982,6 +4219,7 @@ class ExpanderRow(PreferencesRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(PreferencesRow.Props):
         enable_expansion: bool
         expanded: bool
@@ -4990,48 +4228,6 @@ class ExpanderRow(PreferencesRow):
         subtitle: str
         subtitle_lines: int
         title_lines: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -5050,6 +4246,9 @@ class ExpanderRow(PreferencesRow):
         subtitle: str = ...,
         subtitle_lines: int = ...,
         title_lines: int = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         title: str = ...,
         title_selectable: bool = ...,
         use_markup: bool = ...,
@@ -5087,9 +4286,6 @@ class ExpanderRow(PreferencesRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def add_action(self, widget: _Gtk4.Widget) -> None: ...
     def add_prefix(self, widget: _Gtk4.Widget) -> None: ...
@@ -5210,6 +4406,7 @@ class Flap(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         content: _Gtk4.Widget | None
         flap: _Gtk4.Widget | None
@@ -5217,51 +4414,18 @@ class Flap(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         fold_duration: int
         fold_policy: FlapFoldPolicy
         fold_threshold_policy: FoldThresholdPolicy
-        folded: bool
+        @property
+        def folded(self) -> bool: ...
         locked: bool
         modal: bool
         reveal_flap: bool
         reveal_params: SpringParams
-        reveal_progress: float
+        @property
+        def reveal_progress(self) -> float: ...
         separator: _Gtk4.Widget | None
         swipe_to_close: bool
         swipe_to_open: bool
         transition_type: FlapTransitionType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -5284,6 +4448,8 @@ class Flap(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         swipe_to_close: bool = ...,
         swipe_to_open: bool = ...,
         transition_type: FlapTransitionType = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -5314,8 +4480,6 @@ class Flap(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def get_content(self) -> _Gtk4.Widget | None: ...
     def get_flap(self) -> _Gtk4.Widget | None: ...
@@ -5436,6 +4600,7 @@ class HeaderBar(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         centering_policy: CenteringPolicy
         decoration_layout: str | None
@@ -5444,41 +4609,6 @@ class HeaderBar(_Gtk4.Widget):
         show_start_title_buttons: bool
         show_title: bool
         title_widget: _Gtk4.Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -5493,6 +4623,7 @@ class HeaderBar(_Gtk4.Widget):
         show_start_title_buttons: bool = ...,
         show_title: bool = ...,
         title_widget: _Gtk4.Widget | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -5523,7 +4654,6 @@ class HeaderBar(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_centering_policy(self) -> CenteringPolicy: ...
     def get_decoration_layout(self) -> str | None: ...
@@ -5628,46 +4758,12 @@ class InlineViewSwitcher(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         can_shrink: bool
         display_mode: InlineViewSwitcherDisplayMode
         homogeneous: bool
         stack: ViewStack | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -5680,6 +4776,8 @@ class InlineViewSwitcher(_Gtk4.Widget, _Gtk4.Orientable):
         display_mode: InlineViewSwitcherDisplayMode = ...,
         homogeneous: bool = ...,
         stack: ViewStack | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -5710,8 +4808,6 @@ class InlineViewSwitcher(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def get_can_shrink(self) -> bool: ...
     def get_display_mode(self) -> InlineViewSwitcherDisplayMode: ...
@@ -5753,8 +4849,10 @@ class Layout(GObject.Object, _Gtk4.Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        content: _Gtk4.Widget
+        @property
+        def content(self) -> _Gtk4.Widget: ...
         name: str | None
 
     @property
@@ -5848,43 +4946,10 @@ class LayoutSlot(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
-        id: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def id(self) -> str: ...
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -5893,6 +4958,7 @@ class LayoutSlot(_Gtk4.Widget):
         self,
         *,
         id: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -5923,7 +4989,6 @@ class LayoutSlot(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_slot_id(self) -> str: ...
     @classmethod
@@ -6021,55 +5086,24 @@ class Leaflet(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         can_navigate_back: bool
         can_navigate_forward: bool
         can_unfold: bool
         child_transition_params: SpringParams
-        child_transition_running: bool
+        @property
+        def child_transition_running(self) -> bool: ...
         fold_threshold_policy: FoldThresholdPolicy
-        folded: bool
+        @property
+        def folded(self) -> bool: ...
         homogeneous: bool
         mode_transition_duration: int
-        pages: _Gtk4.SelectionModel
+        @property
+        def pages(self) -> _Gtk4.SelectionModel: ...
         transition_type: LeafletTransitionType
         visible_child: _Gtk4.Widget | None
         visible_child_name: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -6088,6 +5122,8 @@ class Leaflet(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         transition_type: LeafletTransitionType = ...,
         visible_child: _Gtk4.Widget = ...,
         visible_child_name: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6118,8 +5154,6 @@ class Leaflet(_Gtk4.Widget, Swipeable, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def append(self, child: _Gtk4.Widget) -> LeafletPage: ...
     def get_adjacent_child(
@@ -6191,8 +5225,10 @@ class LeafletPage(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child: _Gtk4.Widget
+        @property
+        def child(self) -> _Gtk4.Widget: ...
         name: str | None
         navigatable: bool
 
@@ -6335,6 +5371,7 @@ class MessageDialog(_Gtk4.Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Window.Props):
         body: str
         body_use_markup: bool
@@ -6343,68 +5380,7 @@ class MessageDialog(_Gtk4.Window):
         extra_child: _Gtk4.Widget | None
         heading: str | None
         heading_use_markup: bool
-        application: _Gtk4.Application | None
-        child: _Gtk4.Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: _Gtk4.Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: _Gtk4.Widget | None
-        fullscreened: bool
-        gravity: _Gtk4.WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: _Gtk4.Widget | None
-        transient_for: _Gtk4.Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -6420,6 +5396,7 @@ class MessageDialog(_Gtk4.Window):
         extra_child: _Gtk4.Widget | None = ...,
         heading: str | None = ...,
         heading_use_markup: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         application: _Gtk4.Application | None = ...,
         child: _Gtk4.Widget | None = ...,
         decorated: bool = ...,
@@ -6474,7 +5451,6 @@ class MessageDialog(_Gtk4.Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_response(self, id: str, label: str) -> None: ...
     def choose(
@@ -6603,44 +5579,10 @@ class MultiLayoutView(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         layout: Layout | None
         layout_name: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -6650,6 +5592,7 @@ class MultiLayoutView(_Gtk4.Widget):
         *,
         layout: Layout = ...,
         layout_name: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6680,7 +5623,6 @@ class MultiLayoutView(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_layout(self, layout: Layout) -> None: ...
     def get_child(self, id: str) -> _Gtk4.Widget | None: ...
@@ -6784,46 +5726,12 @@ class NavigationPage(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         can_pop: bool
         child: _Gtk4.Widget | None
         tag: str | None
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -6837,6 +5745,7 @@ class NavigationPage(_Gtk4.Widget):
         child: _Gtk4.Widget | None = ...,
         tag: str | None = ...,
         title: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6867,7 +5776,6 @@ class NavigationPage(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def do_hidden(self) -> None: ...
     def do_hiding(self) -> None: ...
@@ -6986,6 +5894,7 @@ class NavigationSplitView(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         collapsed: bool
         content: NavigationPage | None
@@ -6996,41 +5905,6 @@ class NavigationSplitView(_Gtk4.Widget):
         sidebar_position: _Gtk4.PackType
         sidebar_width_fraction: float
         sidebar_width_unit: LengthUnit
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -7047,6 +5921,7 @@ class NavigationSplitView(_Gtk4.Widget):
         sidebar_position: _Gtk4.PackType = ...,
         sidebar_width_fraction: float = ...,
         sidebar_width_unit: LengthUnit = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -7077,7 +5952,6 @@ class NavigationSplitView(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_collapsed(self) -> bool: ...
     def get_content(self) -> NavigationPage | None: ...
@@ -7192,49 +6066,18 @@ class NavigationView(_Gtk4.Widget, Swipeable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         animate_transitions: bool
         hhomogeneous: bool
-        navigation_stack: Gio.ListModel
+        @property
+        def navigation_stack(self) -> Gio.ListModel: ...
         pop_on_escape: bool
         vhomogeneous: bool
-        visible_page: NavigationPage | None
-        visible_page_tag: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def visible_page(self) -> NavigationPage | None: ...
+        @property
+        def visible_page_tag(self) -> str | None: ...
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -7246,6 +6089,7 @@ class NavigationView(_Gtk4.Widget, Swipeable):
         hhomogeneous: bool = ...,
         pop_on_escape: bool = ...,
         vhomogeneous: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -7276,7 +6120,6 @@ class NavigationView(_Gtk4.Widget, Swipeable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, page: NavigationPage) -> None: ...
     def find_page(self, tag: str) -> NavigationPage | None: ...
@@ -7394,6 +6237,7 @@ class OverlaySplitView(_Gtk4.Widget, Swipeable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         collapsed: bool
         content: _Gtk4.Widget | None
@@ -7407,41 +6251,6 @@ class OverlaySplitView(_Gtk4.Widget, Swipeable):
         sidebar_position: _Gtk4.PackType
         sidebar_width_fraction: float
         sidebar_width_unit: LengthUnit
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -7461,6 +6270,7 @@ class OverlaySplitView(_Gtk4.Widget, Swipeable):
         sidebar_position: _Gtk4.PackType = ...,
         sidebar_width_fraction: float = ...,
         sidebar_width_unit: LengthUnit = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -7491,7 +6301,6 @@ class OverlaySplitView(_Gtk4.Widget, Swipeable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_collapsed(self) -> bool: ...
     def get_content(self) -> _Gtk4.Widget | None: ...
@@ -7635,65 +6444,18 @@ class PasswordEntryRow(EntryRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EntryRow.Props):
-        activates_default: bool
-        attributes: Pango.AttrList | None
-        enable_emoji_completion: bool
-        input_hints: _Gtk4.InputHints
-        input_purpose: _Gtk4.InputPurpose
-        max_length: int
-        show_apply_button: bool
-        text_length: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -7703,6 +6465,15 @@ class PasswordEntryRow(EntryRow):
     def __init__(
         self,
         *,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         activates_default: bool = ...,
         attributes: Pango.AttrList | None = ...,
         enable_emoji_completion: bool = ...,
@@ -7747,15 +6518,6 @@ class PasswordEntryRow(EntryRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> PasswordEntryRow: ...
@@ -7858,55 +6620,11 @@ class PreferencesDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         search_enabled: bool
         visible_page: _Gtk4.Widget | None
         visible_page_name: str | None
-        can_close: bool
-        child: _Gtk4.Widget | None
-        content_height: int
-        content_width: int
-        current_breakpoint: Breakpoint | None
-        default_widget: _Gtk4.Widget | None
-        focus_widget: _Gtk4.Widget | None
-        follows_content_size: bool
-        presentation_mode: DialogPresentationMode
-        title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -7919,6 +6637,7 @@ class PreferencesDialog(Dialog):
         search_enabled: bool = ...,
         visible_page: _Gtk4.Widget = ...,
         visible_page_name: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_close: bool = ...,
         child: _Gtk4.Widget | None = ...,
         content_height: int = ...,
@@ -7958,7 +6677,6 @@ class PreferencesDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, page: PreferencesPage) -> None: ...
     def add_toast(self, toast: Toast) -> None: ...
@@ -8059,46 +6777,12 @@ class PreferencesGroup(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         description: str | None
         header_suffix: _Gtk4.Widget | None
         separate_rows: bool
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -8112,6 +6796,7 @@ class PreferencesGroup(_Gtk4.Widget):
         header_suffix: _Gtk4.Widget | None = ...,
         separate_rows: bool = ...,
         title: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -8142,7 +6827,6 @@ class PreferencesGroup(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, child: _Gtk4.Widget) -> None: ...
     def bind_model(
@@ -8252,6 +6936,7 @@ class PreferencesPage(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         banner: Banner | None
         description: str
@@ -8260,40 +6945,6 @@ class PreferencesPage(_Gtk4.Widget):
         name: str | None
         title: str
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -8310,6 +6961,7 @@ class PreferencesPage(_Gtk4.Widget):
         name: str | None = ...,
         title: str = ...,
         use_underline: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -8339,7 +6991,6 @@ class PreferencesPage(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, group: PreferencesGroup) -> None: ...
     def get_banner(self) -> Banner | None: ...
@@ -8456,49 +7107,12 @@ class PreferencesRow(_Gtk4.ListBoxRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.ListBoxRow.Props):
         title: str
         title_selectable: bool
         use_markup: bool
         use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -8514,6 +7128,9 @@ class PreferencesRow(_Gtk4.ListBoxRow):
         title_selectable: bool = ...,
         use_markup: bool = ...,
         use_underline: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         activatable: bool = ...,
         child: _Gtk4.Widget | None = ...,
         selectable: bool = ...,
@@ -8547,9 +7164,6 @@ class PreferencesRow(_Gtk4.ListBoxRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_title(self) -> str: ...
     def get_title_selectable(self) -> bool: ...
@@ -8689,78 +7303,13 @@ class PreferencesWindow(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         can_navigate_back: bool
         search_enabled: bool
         visible_page: _Gtk4.Widget | None
         visible_page_name: str | None
-        adaptive_preview: bool
-        content: _Gtk4.Widget | None
-        current_breakpoint: Breakpoint | None
-        dialogs: Gio.ListModel
-        visible_dialog: Dialog | None
-        application: _Gtk4.Application | None
-        child: _Gtk4.Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: _Gtk4.Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: _Gtk4.Widget | None
-        fullscreened: bool
-        gravity: _Gtk4.WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: _Gtk4.Widget | None
-        transient_for: _Gtk4.Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -8773,6 +7322,7 @@ class PreferencesWindow(Window):
         search_enabled: bool = ...,
         visible_page: _Gtk4.Widget = ...,
         visible_page_name: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         adaptive_preview: bool = ...,
         content: _Gtk4.Widget | None = ...,
         application: _Gtk4.Application | None = ...,
@@ -8829,7 +7379,6 @@ class PreferencesWindow(Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, page: PreferencesPage) -> None: ...
     def add_toast(self, toast: Toast) -> None: ...
@@ -8881,9 +7430,12 @@ class PropertyAnimationTarget(AnimationTarget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(AnimationTarget.Props):
-        object: GObject.Object
-        pspec: GObject.ParamSpec
+        @property
+        def object(self) -> GObject.Object: ...
+        @property
+        def pspec(self) -> GObject.ParamSpec: ...
 
     @property
     def props(self) -> Props: ...
@@ -8973,44 +7525,10 @@ class ShortcutLabel(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         accelerator: str
         disabled_text: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -9020,6 +7538,7 @@ class ShortcutLabel(_Gtk4.Widget):
         *,
         accelerator: str = ...,
         disabled_text: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -9050,7 +7569,6 @@ class ShortcutLabel(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_accelerator(self) -> str: ...
     def get_disabled_text(self) -> str: ...
@@ -9152,52 +7670,8 @@ class ShortcutsDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        can_close: bool
-        child: _Gtk4.Widget | None
-        content_height: int
-        content_width: int
-        current_breakpoint: Breakpoint | None
-        default_widget: _Gtk4.Widget | None
-        focus_widget: _Gtk4.Widget | None
-        follows_content_size: bool
-        presentation_mode: DialogPresentationMode
-        title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -9205,6 +7679,7 @@ class ShortcutsDialog(Dialog):
     def __init__(
         self,
         *,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_close: bool = ...,
         child: _Gtk4.Widget | None = ...,
         content_height: int = ...,
@@ -9244,7 +7719,6 @@ class ShortcutsDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, section: ShortcutsSection) -> None: ...
     @classmethod
@@ -9283,6 +7757,7 @@ class ShortcutsItem(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accelerator: str
         action_name: str
@@ -9347,6 +7822,7 @@ class ShortcutsSection(GObject.Object, Gio.ListModel, _Gtk4.Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         title: str | None
 
@@ -9482,8 +7958,9 @@ class SpinRow(ActionRow, _Gtk4.Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ActionRow.Props):
-        adjustment: _Gtk4.Adjustment
+        adjustment: _Gtk4.Adjustment | None
         climb_rate: float
         digits: int
         numeric: bool
@@ -9491,62 +7968,16 @@ class SpinRow(ActionRow, _Gtk4.Editable):
         update_policy: _Gtk4.SpinButtonUpdatePolicy
         value: float
         wrap: bool
-        activatable_widget: _Gtk4.Widget | None
-        icon_name: str | None
-        subtitle: str | None
-        subtitle_lines: int
-        subtitle_selectable: bool
-        title_lines: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -9564,6 +7995,15 @@ class SpinRow(ActionRow, _Gtk4.Editable):
         update_policy: _Gtk4.SpinButtonUpdatePolicy = ...,
         value: float = ...,
         wrap: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         activatable_widget: _Gtk4.Widget | None = ...,
         icon_name: str | None = ...,
         subtitle: str = ...,
@@ -9607,15 +8047,6 @@ class SpinRow(ActionRow, _Gtk4.Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def configure(
         self, adjustment: _Gtk4.Adjustment | None, climb_rate: float, digits: int
@@ -9722,42 +8153,8 @@ class Spinner(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -9765,6 +8162,7 @@ class Spinner(_Gtk4.Widget):
     def __init__(
         self,
         *,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -9795,7 +8193,6 @@ class Spinner(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> Spinner: ...
@@ -9832,6 +8229,7 @@ class SpinnerPaintable(GObject.Object, _Gdk4.Paintable, _Gtk4.SymbolicPaintable)
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         widget: _Gtk4.Widget | None
 
@@ -9935,6 +8333,7 @@ class SplitButton(_Gtk4.Widget, _Gtk4.Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         can_shrink: bool
         child: _Gtk4.Widget | None
@@ -9945,41 +8344,6 @@ class SplitButton(_Gtk4.Widget, _Gtk4.Actionable):
         menu_model: Gio.MenuModel | None
         popover: _Gtk4.Popover | None
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -9998,6 +8362,9 @@ class SplitButton(_Gtk4.Widget, _Gtk4.Actionable):
         menu_model: Gio.MenuModel | None = ...,
         popover: _Gtk4.Popover | None = ...,
         use_underline: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -10028,9 +8395,6 @@ class SplitButton(_Gtk4.Widget, _Gtk4.Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_can_shrink(self) -> bool: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
@@ -10100,20 +8464,18 @@ class SpringAnimation(Animation):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Animation.Props):
         clamp: bool
         epsilon: float
-        estimated_duration: int
+        @property
+        def estimated_duration(self) -> int: ...
         initial_velocity: float
         spring_params: SpringParams
         value_from: float
         value_to: float
-        velocity: float
-        follow_enable_animations_setting: bool
-        state: AnimationState
-        target: AnimationTarget
-        value: float
-        widget: _Gtk4.Widget
+        @property
+        def velocity(self) -> float: ...
 
     @property
     def props(self) -> Props: ...
@@ -10265,53 +8627,22 @@ class Squeezer(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         allow_none: bool
         homogeneous: bool
         interpolate_size: bool
-        pages: _Gtk4.SelectionModel
+        @property
+        def pages(self) -> _Gtk4.SelectionModel: ...
         switch_threshold_policy: FoldThresholdPolicy
         transition_duration: int
-        transition_running: bool
+        @property
+        def transition_running(self) -> bool: ...
         transition_type: SqueezerTransitionType
-        visible_child: _Gtk4.Widget | None
+        @property
+        def visible_child(self) -> _Gtk4.Widget | None: ...
         xalign: float
         yalign: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -10328,6 +8659,8 @@ class Squeezer(_Gtk4.Widget, _Gtk4.Orientable):
         transition_type: SqueezerTransitionType = ...,
         xalign: float = ...,
         yalign: float = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -10358,8 +8691,6 @@ class Squeezer(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def add(self, child: _Gtk4.Widget) -> SqueezerPage: ...
     def get_allow_none(self) -> bool: ...
@@ -10414,8 +8745,10 @@ class SqueezerPage(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child: _Gtk4.Widget
+        @property
+        def child(self) -> _Gtk4.Widget: ...
         enabled: bool
 
     @property
@@ -10509,47 +8842,13 @@ class StatusPage(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
         description: str | None
         icon_name: str | None
         paintable: _Gdk4.Paintable | None
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -10562,6 +8861,7 @@ class StatusPage(_Gtk4.Widget):
         icon_name: str | None = ...,
         paintable: _Gdk4.Paintable | None = ...,
         title: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -10592,7 +8892,6 @@ class StatusPage(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
     def get_description(self) -> str | None: ...
@@ -10643,17 +8942,27 @@ class StyleManager(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        accent_color: AccentColor
-        accent_color_rgba: _Gdk4.RGBA
+        @property
+        def accent_color(self) -> AccentColor: ...
+        @property
+        def accent_color_rgba(self) -> _Gdk4.RGBA: ...
         color_scheme: ColorScheme
-        dark: bool
-        display: _Gdk4.Display | None
-        document_font_name: str
-        high_contrast: bool
-        monospace_font_name: str
-        system_supports_accent_colors: bool
-        system_supports_color_schemes: bool
+        @property
+        def dark(self) -> bool: ...
+        @property
+        def display(self) -> _Gdk4.Display | None: ...
+        @property
+        def document_font_name(self) -> str: ...
+        @property
+        def high_contrast(self) -> bool: ...
+        @property
+        def monospace_font_name(self) -> str: ...
+        @property
+        def system_supports_accent_colors(self) -> bool: ...
+        @property
+        def system_supports_color_schemes(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -10717,6 +9026,7 @@ class SwipeTracker(GObject.Object, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         allow_long_swipes: bool
         allow_mouse_drag: bool
@@ -10724,7 +9034,8 @@ class SwipeTracker(GObject.Object, _Gtk4.Orientable):
         enabled: bool
         lower_overshoot: bool
         reversed: bool
-        swipeable: Swipeable
+        @property
+        def swipeable(self) -> Swipeable: ...
         upper_overshoot: bool
         orientation: _Gtk4.Orientation
 
@@ -10907,56 +9218,9 @@ class SwitchRow(ActionRow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ActionRow.Props):
         active: bool
-        activatable_widget: _Gtk4.Widget | None
-        icon_name: str | None
-        subtitle: str | None
-        subtitle_lines: int
-        subtitle_selectable: bool
-        title_lines: int
-        title: str
-        title_selectable: bool
-        use_markup: bool
-        use_underline: bool
-        activatable: bool
-        child: _Gtk4.Widget | None
-        selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -10967,6 +9231,9 @@ class SwitchRow(ActionRow):
         self,
         *,
         active: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         activatable_widget: _Gtk4.Widget | None = ...,
         icon_name: str | None = ...,
         subtitle: str = ...,
@@ -11010,9 +9277,6 @@ class SwitchRow(ActionRow):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_active(self) -> bool: ...
     @classmethod
@@ -11112,52 +9376,21 @@ class TabBar(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         autohide: bool
         end_action_widget: _Gtk4.Widget | None
         expand_tabs: bool
-        extra_drag_preferred_action: _Gdk4.DragAction
+        @property
+        def extra_drag_preferred_action(self) -> _Gdk4.DragAction: ...
         extra_drag_preload: bool
         inverted: bool
-        is_overflowing: bool
+        @property
+        def is_overflowing(self) -> bool: ...
         start_action_widget: _Gtk4.Widget | None
-        tabs_revealed: bool
+        @property
+        def tabs_revealed(self) -> bool: ...
         view: TabView | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -11172,6 +9405,7 @@ class TabBar(_Gtk4.Widget):
         inverted: bool = ...,
         start_action_widget: _Gtk4.Widget | None = ...,
         view: TabView | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -11202,7 +9436,6 @@ class TabBar(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_autohide(self) -> bool: ...
     def get_end_action_widget(self) -> _Gtk4.Widget | None: ...
@@ -11311,43 +9544,9 @@ class TabButton(_Gtk4.Widget, _Gtk4.Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         view: TabView | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -11358,6 +9557,9 @@ class TabButton(_Gtk4.Widget, _Gtk4.Actionable):
         self,
         *,
         view: TabView | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -11388,9 +9590,6 @@ class TabButton(_Gtk4.Widget, _Gtk4.Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_view(self) -> TabView | None: ...
     @classmethod
@@ -11493,54 +9692,22 @@ class TabOverview(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
         enable_new_tab: bool
         enable_search: bool
-        extra_drag_preferred_action: _Gdk4.DragAction
+        @property
+        def extra_drag_preferred_action(self) -> _Gdk4.DragAction: ...
         extra_drag_preload: bool
         inverted: bool
         open: bool
-        search_active: bool
+        @property
+        def search_active(self) -> bool: ...
         secondary_menu: Gio.MenuModel | None
         show_end_title_buttons: bool
         show_start_title_buttons: bool
         view: TabView | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -11558,6 +9725,7 @@ class TabOverview(_Gtk4.Widget):
         show_end_title_buttons: bool = ...,
         show_start_title_buttons: bool = ...,
         view: TabView | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -11588,7 +9756,6 @@ class TabOverview(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> _Gtk4.Widget | None: ...
     def get_enable_new_tab(self) -> bool: ...
@@ -11662,8 +9829,10 @@ class TabPage(GObject.Object, _Gtk4.Accessible):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child: _Gtk4.Widget
+        @property
+        def child(self) -> _Gtk4.Widget: ...
         icon: Gio.Icon | None
         indicator_activatable: bool
         indicator_icon: Gio.Icon | None
@@ -11672,9 +9841,12 @@ class TabPage(GObject.Object, _Gtk4.Accessible):
         live_thumbnail: bool
         loading: bool
         needs_attention: bool
-        parent: TabPage | None
-        pinned: bool
-        selected: bool
+        @property
+        def parent(self) -> TabPage | None: ...
+        @property
+        def pinned(self) -> bool: ...
+        @property
+        def selected(self) -> bool: ...
         thumbnail_xalign: float
         thumbnail_yalign: float
         title: str
@@ -11828,50 +10000,20 @@ class TabView(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         default_icon: Gio.Icon
-        is_transferring_page: bool
+        @property
+        def is_transferring_page(self) -> bool: ...
         menu_model: Gio.MenuModel | None
-        n_pages: int
-        n_pinned_pages: int
-        pages: _Gtk4.SelectionModel
+        @property
+        def n_pages(self) -> int: ...
+        @property
+        def n_pinned_pages(self) -> int: ...
+        @property
+        def pages(self) -> _Gtk4.SelectionModel: ...
         selected_page: TabPage | None
         shortcuts: TabViewShortcuts
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -11883,6 +10025,7 @@ class TabView(_Gtk4.Widget):
         menu_model: Gio.MenuModel | None = ...,
         selected_page: TabPage = ...,
         shortcuts: TabViewShortcuts = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -11913,7 +10056,6 @@ class TabView(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_page(
         self, child: _Gtk4.Widget, parent: TabPage | None = None
@@ -12005,6 +10147,7 @@ class TimedAnimation(Animation):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Animation.Props):
         alternate: bool
         duration: int
@@ -12013,11 +10156,6 @@ class TimedAnimation(Animation):
         reverse: bool
         value_from: float
         value_to: float
-        follow_enable_animations_setting: bool
-        state: AnimationState
-        target: AnimationTarget
-        value: float
-        widget: _Gtk4.Widget
 
     @property
     def props(self) -> Props: ...
@@ -12089,6 +10227,7 @@ class Toast(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         action_name: str | None
         action_target: GLib.Variant | None
@@ -12218,43 +10357,9 @@ class ToastOverlay(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         child: _Gtk4.Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -12263,6 +10368,7 @@ class ToastOverlay(_Gtk4.Widget):
         self,
         *,
         child: _Gtk4.Widget | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -12293,7 +10399,6 @@ class ToastOverlay(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_toast(self, toast: Toast) -> None: ...
     def dismiss_all(self) -> None: ...
@@ -12336,12 +10441,13 @@ class Toggle(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         child: _Gtk4.Widget | None
         enabled: bool
         icon_name: str | None
         label: str | None
-        name: str
+        name: str | None
         tooltip: str
         use_underline: bool
 
@@ -12461,48 +10567,16 @@ class ToggleGroup(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         active: int
         active_name: str | None
         can_shrink: bool
         homogeneous: bool
-        n_toggles: int
-        toggles: _Gtk4.SelectionModel
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def n_toggles(self) -> int: ...
+        @property
+        def toggles(self) -> _Gtk4.SelectionModel: ...
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -12515,6 +10589,8 @@ class ToggleGroup(_Gtk4.Widget, _Gtk4.Orientable):
         active_name: str | None = ...,
         can_shrink: bool = ...,
         homogeneous: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -12545,8 +10621,6 @@ class ToggleGroup(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def add(self, toggle: Toggle) -> None: ...
     def get_active(self) -> int: ...
@@ -12654,51 +10728,19 @@ class ToolbarView(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
-        bottom_bar_height: int
+        @property
+        def bottom_bar_height(self) -> int: ...
         bottom_bar_style: ToolbarStyle
         content: _Gtk4.Widget | None
         extend_content_to_bottom_edge: bool
         extend_content_to_top_edge: bool
         reveal_bottom_bars: bool
         reveal_top_bars: bool
-        top_bar_height: int
+        @property
+        def top_bar_height(self) -> int: ...
         top_bar_style: ToolbarStyle
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -12713,6 +10755,7 @@ class ToolbarView(_Gtk4.Widget):
         reveal_bottom_bars: bool = ...,
         reveal_top_bars: bool = ...,
         top_bar_style: ToolbarStyle = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -12743,7 +10786,6 @@ class ToolbarView(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_bottom_bar(self, widget: _Gtk4.Widget) -> None: ...
     def add_top_bar(self, widget: _Gtk4.Widget) -> None: ...
@@ -12854,50 +10896,18 @@ class ViewStack(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         enable_transitions: bool
         hhomogeneous: bool
-        pages: _Gtk4.SelectionModel
+        @property
+        def pages(self) -> _Gtk4.SelectionModel: ...
         transition_duration: int
-        transition_running: bool
+        @property
+        def transition_running(self) -> bool: ...
         vhomogeneous: bool
         visible_child: _Gtk4.Widget | None
         visible_child_name: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -12911,6 +10921,7 @@ class ViewStack(_Gtk4.Widget):
         vhomogeneous: bool = ...,
         visible_child: _Gtk4.Widget = ...,
         visible_child_name: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -12941,7 +10952,6 @@ class ViewStack(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add(self, child: _Gtk4.Widget) -> ViewStackPage: ...
     def add_named(
@@ -13007,9 +11017,11 @@ class ViewStackPage(GObject.Object, _Gtk4.Accessible):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         badge_number: int
-        child: _Gtk4.Widget
+        @property
+        def child(self) -> _Gtk4.Widget: ...
         icon_name: str | None
         name: str | None
         needs_attention: bool
@@ -13082,6 +11094,7 @@ class ViewStackPages(GObject.Object, Gio.ListModel, _Gtk4.SelectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         selected_page: ViewStackPage | None
 
@@ -13172,44 +11185,10 @@ class ViewSwitcher(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         policy: ViewSwitcherPolicy
         stack: ViewStack | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -13219,6 +11198,7 @@ class ViewSwitcher(_Gtk4.Widget):
         *,
         policy: ViewSwitcherPolicy = ...,
         stack: ViewStack | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -13249,7 +11229,6 @@ class ViewSwitcher(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_policy(self) -> ViewSwitcherPolicy: ...
     def get_stack(self) -> ViewStack | None: ...
@@ -13328,44 +11307,10 @@ class ViewSwitcherBar(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         reveal: bool
         stack: ViewStack | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -13375,6 +11320,7 @@ class ViewSwitcherBar(_Gtk4.Widget):
         *,
         reveal: bool = ...,
         stack: ViewStack | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -13405,7 +11351,6 @@ class ViewSwitcherBar(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_reveal(self) -> bool: ...
     def get_stack(self) -> ViewStack | None: ...
@@ -13509,47 +11454,14 @@ class ViewSwitcherTitle(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         stack: ViewStack | None
         subtitle: str
         title: str
-        title_visible: bool
+        @property
+        def title_visible(self) -> bool: ...
         view_switcher_enabled: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -13561,6 +11473,7 @@ class ViewSwitcherTitle(_Gtk4.Widget):
         subtitle: str = ...,
         title: str = ...,
         view_switcher_enabled: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -13591,7 +11504,6 @@ class ViewSwitcherTitle(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_stack(self) -> ViewStack | None: ...
     def get_subtitle(self) -> str: ...
@@ -13724,74 +11636,17 @@ class Window(_Gtk4.Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Window.Props):
         adaptive_preview: bool
         content: _Gtk4.Widget | None
-        current_breakpoint: Breakpoint | None
-        dialogs: Gio.ListModel
-        visible_dialog: Dialog | None
-        application: _Gtk4.Application | None
-        child: _Gtk4.Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: _Gtk4.Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: _Gtk4.Widget | None
-        fullscreened: bool
-        gravity: _Gtk4.WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: _Gtk4.Widget | None
-        transient_for: _Gtk4.Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def current_breakpoint(self) -> Breakpoint | None: ...
+        @property
+        def dialogs(self) -> Gio.ListModel: ...
+        @property
+        def visible_dialog(self) -> Dialog | None: ...
         accessible_role: _Gtk4.AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -13802,6 +11657,7 @@ class Window(_Gtk4.Window):
         *,
         adaptive_preview: bool = ...,
         content: _Gtk4.Widget | None = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         application: _Gtk4.Application | None = ...,
         child: _Gtk4.Widget | None = ...,
         decorated: bool = ...,
@@ -13856,7 +11712,6 @@ class Window(_Gtk4.Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def add_breakpoint(self, breakpoint: Breakpoint) -> None: ...
     def get_adaptive_preview(self) -> bool: ...
@@ -13952,44 +11807,10 @@ class WindowTitle(_Gtk4.Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         subtitle: str
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
 
     @property
@@ -13999,6 +11820,7 @@ class WindowTitle(_Gtk4.Widget):
         *,
         subtitle: str = ...,
         title: str = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -14029,7 +11851,6 @@ class WindowTitle(_Gtk4.Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
     ) -> None: ...
     def get_subtitle(self) -> str: ...
     def get_title(self) -> str: ...
@@ -14130,6 +11951,7 @@ class WrapBox(_Gtk4.Widget, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.Widget.Props):
         align: float
         child_spacing: int
@@ -14144,41 +11966,6 @@ class WrapBox(_Gtk4.Widget, _Gtk4.Orientable):
         pack_direction: PackDirection
         wrap_policy: WrapPolicy
         wrap_reverse: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: _Gtk4.Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: _Gtk4.LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: _Gtk4.Overflow
-        parent: _Gtk4.Widget | None
-        receives_default: bool
-        root: _Gtk4.Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: _Gtk4.Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: _Gtk4.AccessibleRole
         orientation: _Gtk4.Orientation
 
@@ -14200,6 +11987,8 @@ class WrapBox(_Gtk4.Widget, _Gtk4.Orientable):
         pack_direction: PackDirection = ...,
         wrap_policy: WrapPolicy = ...,
         wrap_reverse: bool = ...,
+        accessible_role: _Gtk4.AccessibleRole = ...,
+        orientation: _Gtk4.Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -14230,8 +12019,6 @@ class WrapBox(_Gtk4.Widget, _Gtk4.Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: _Gtk4.AccessibleRole = ...,
-        orientation: _Gtk4.Orientation = ...,
     ) -> None: ...
     def append(self, child: _Gtk4.Widget) -> None: ...
     def get_align(self) -> float: ...
@@ -14312,6 +12099,7 @@ class WrapLayout(_Gtk4.LayoutManager, _Gtk4.Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gtk4.LayoutManager.Props):
         align: float
         child_spacing: int

--- a/src/gi-stubs/repository/Atk.pyi
+++ b/src/gi-stubs/repository/Atk.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -331,27 +332,6 @@ class GObjectAccessible(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Object
-        accessible_role: Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Object
-        accessible_table_summary: Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Object: ...
     def __init__(
@@ -417,11 +397,16 @@ class Hyperlink(GObject.Object, Action):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        end_index: int
-        number_of_anchors: int
-        selected_link: bool
-        start_index: int
+        @property
+        def end_index(self) -> int: ...
+        @property
+        def number_of_anchors(self) -> int: ...
+        @property
+        def selected_link(self) -> bool: ...
+        @property
+        def start_index(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -556,7 +541,10 @@ class ImageIface(_gi.Struct):
 class Implementor(_gi.Struct):
     def ref_accessible(self) -> Object: ...
 
-class ImplementorIface(GObject.GInterface, Protocol): ...
+class ImplementorIface(GObject.GInterface, Protocol):
+    """
+    Interface AtkImplementorIface
+    """
 
 class KeyEventStruct(_gi.Struct):
     """
@@ -736,27 +724,6 @@ class NoOpObject(
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Object
-        accessible_role: Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Object
-        accessible_table_summary: Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Object: ...
     def __init__(
@@ -881,12 +848,16 @@ class Object(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
+        @property
+        def accessible_component_layer(self) -> int: ...
+        @property
+        def accessible_component_mdi_zorder(self) -> int: ...
         accessible_description: str
         accessible_help_text: str
-        accessible_hypertext_nlinks: int
+        @property
+        def accessible_hypertext_nlinks(self) -> int: ...
         accessible_id: str
         accessible_name: str
         accessible_parent: Object
@@ -1158,27 +1129,6 @@ class Plug(Object, Component):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Object
-        accessible_role: Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Object
-        accessible_table_summary: Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Object: ...
     def __init__(
@@ -1319,6 +1269,7 @@ class Relation(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         relation_type: RelationType
         target: GObject.ValueArray
@@ -1501,27 +1452,6 @@ class Socket(Object, Component):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Object
-        accessible_role: Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Object
-        accessible_table_summary: Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Object: ...
     @property
@@ -2062,7 +1992,13 @@ class ValueIface(_gi.Struct):
     @property
     def set_value(self) -> Callable[[Value, float], None]: ...
 
-class Window(GObject.GInterface, Protocol): ...
+class Window(GObject.GInterface, Protocol):
+    """
+    Interface AtkWindow
+
+    Signals from GObject:
+      notify (GParam)
+    """
 
 class WindowIface(_gi.Struct):
     """

--- a/src/gi-stubs/repository/GLib.pyi
+++ b/src/gi-stubs/repository/GLib.pyi
@@ -1968,7 +1968,8 @@ class IOChannel(GObject.GBoxed):
     def reserved1(self) -> None: ...
     @property
     def reserved2(self) -> None: ...
-    def __iter__(self): ...  # FIXME: Override is missing typing annotation
+    # override
+    def __iter__(self) -> Self: ...
     @staticmethod
     def __new__(
         cls: type[Self],
@@ -1977,6 +1978,7 @@ class IOChannel(GObject.GBoxed):
         mode: str | None = None,
         hwnd: int | None = None,
     ) -> Self: ...
+    def __next__(self) -> str: ...
     def add_watch(
         self,
         condition: IOCondition,

--- a/src/gi-stubs/repository/GObject.pyi
+++ b/src/gi-stubs/repository/GObject.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 
 from builtins import property as _property
@@ -837,12 +838,18 @@ class Binding(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
-        flags: BindingFlags
-        source: Object | None
-        source_property: str
-        target: Object | None
-        target_property: str
+        @_property
+        def flags(self) -> BindingFlags: ...
+        @_property
+        def source(self) -> Object | None: ...
+        @_property
+        def source_property(self) -> str: ...
+        @_property
+        def target(self) -> Object | None: ...
+        @_property
+        def target_property(self) -> str: ...
 
     @_property
     def props(self) -> Props: ...
@@ -881,6 +888,7 @@ class BindingGroup(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         source: Object | None
 
@@ -1252,7 +1260,11 @@ class FlagsValue(_gi.Struct):
     value_name: str
     value_nick: str
 
-class Float(float): ...
+class Float(float):
+    """
+    A wrapper to force conversion to G_TYPE_FLOAT instead of G_TYPE_DOUBLE when
+    used in GValue APIs.
+    """
 
 GBoxed = _gi.GBoxed
 GError = GLib.GError
@@ -1956,9 +1968,11 @@ class SignalGroup(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         target: Object | None
-        target_type: type[Any]
+        @_property
+        def target_type(self) -> type[Any]: ...
 
     @_property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/GdkPixbuf.pyi
+++ b/src/gi-stubs/repository/GdkPixbuf.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -67,16 +68,26 @@ class Pixbuf(GObject.Object, Gio.Icon, Gio.LoadableIcon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        bits_per_sample: int
-        colorspace: Colorspace
-        has_alpha: bool
-        height: int
-        n_channels: int
-        pixel_bytes: GLib.Bytes
-        pixels: None
-        rowstride: int
-        width: int
+        @property
+        def bits_per_sample(self) -> int: ...
+        @property
+        def colorspace(self) -> Colorspace: ...
+        @property
+        def has_alpha(self) -> bool: ...
+        @property
+        def height(self) -> int: ...
+        @property
+        def n_channels(self) -> int: ...
+        @property
+        def pixel_bytes(self) -> GLib.Bytes: ...
+        @property
+        def pixels(self) -> None: ...
+        @property
+        def rowstride(self) -> int: ...
+        @property
+        def width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -626,6 +637,7 @@ class PixbufSimpleAnim(PixbufAnimation):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(PixbufAnimation.Props):
         loop: bool
 
@@ -639,7 +651,20 @@ class PixbufSimpleAnim(PixbufAnimation):
     def set_loop(self, loop: bool) -> None: ...
 
 class PixbufSimpleAnimClass(_gi.Struct): ...
-class PixbufSimpleAnimIter(PixbufAnimationIter): ...
+
+class PixbufSimpleAnimIter(PixbufAnimationIter):
+    """
+    :Constructors:
+
+    ::
+
+        PixbufSimpleAnimIter(**properties)
+
+    Object GdkPixbufSimpleAnimIter
+
+    Signals from GObject:
+      notify (GParam)
+    """
 
 class PixbufFormatFlags(IntFlag):
     SCALABLE = 2

--- a/src/gi-stubs/repository/GdkX11.pyi
+++ b/src/gi-stubs/repository/GdkX11.pyi
@@ -1,3 +1,4 @@
+from typing import type_check_only
 from typing import TypeVar
 
 from enum import IntEnum
@@ -5,7 +6,6 @@ from enum import IntEnum
 from gi import _gi
 from gi.repository import _Gdk4
 from gi.repository import GObject
-from gi.repository import Pango
 from gi.repository import xlib
 
 T = TypeVar("T")
@@ -43,11 +43,6 @@ class X11AppLaunchContext(_Gdk4.AppLaunchContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(_Gdk4.AppLaunchContext.Props):
-        display: _Gdk4.Display
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, display: _Gdk4.Display = ...) -> None: ...
 
 class X11AppLaunchContextClass(_gi.Struct): ...
@@ -71,11 +66,16 @@ class X11DeviceManagerXI2(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: _Gdk4.Display
-        major: int
-        minor: int
-        opcode: int
+        @property
+        def display(self) -> _Gdk4.Display: ...
+        @property
+        def major(self) -> int: ...
+        @property
+        def minor(self) -> int: ...
+        @property
+        def opcode(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -130,26 +130,10 @@ class X11DeviceXI2(_Gdk4.Device):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(_Gdk4.Device.Props):
-        device_id: int
-        active_layout_index: int
-        caps_lock_state: bool
-        direction: Pango.Direction
-        display: _Gdk4.Display
-        has_bidi_layouts: bool
-        has_cursor: bool
-        layout_names: list[str] | None
-        modifier_state: _Gdk4.ModifierType
-        n_axes: int
-        name: str
-        num_lock_state: bool
-        num_touches: int
-        product_id: str | None
-        scroll_lock_state: bool
-        seat: _Gdk4.Seat
-        source: _Gdk4.InputSource
-        tool: _Gdk4.DeviceTool | None
-        vendor_id: str | None
+        @property
+        def device_id(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -199,15 +183,6 @@ class X11Display(_Gdk4.Display):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(_Gdk4.Display.Props):
-        composited: bool
-        dmabuf_formats: _Gdk4.DmabufFormats
-        input_shapes: bool
-        rgba: bool
-        shadow_width: bool
-
-    @property
-    def props(self) -> Props: ...
     def error_trap_pop(self) -> int: ...
     def error_trap_pop_ignored(self) -> None: ...
     def error_trap_push(self) -> None: ...
@@ -267,17 +242,6 @@ class X11Drag(_Gdk4.Drag):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(_Gdk4.Drag.Props):
-        actions: _Gdk4.DragAction
-        content: _Gdk4.ContentProvider
-        device: _Gdk4.Device
-        display: _Gdk4.Display
-        formats: _Gdk4.ContentFormats
-        selected_action: _Gdk4.DragAction
-        surface: _Gdk4.Surface
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -313,15 +277,6 @@ class X11GLContext(_Gdk4.GLContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(_Gdk4.GLContext.Props):
-        allowed_apis: _Gdk4.GLAPI
-        api: _Gdk4.GLAPI
-        shared_context: _Gdk4.GLContext | None
-        display: _Gdk4.Display | None
-        surface: _Gdk4.Surface | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -364,23 +319,6 @@ class X11Monitor(_Gdk4.Monitor):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(_Gdk4.Monitor.Props):
-        connector: str | None
-        description: str | None
-        display: _Gdk4.Display
-        geometry: _Gdk4.Rectangle
-        height_mm: int
-        manufacturer: str | None
-        model: str | None
-        refresh_rate: int
-        scale: float
-        scale_factor: int
-        subpixel_layout: _Gdk4.SubpixelLayout
-        valid: bool
-        width_mm: int
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, display: _Gdk4.Display = ...) -> None: ...
     def get_output(self) -> int: ...
     def get_workarea(self) -> _Gdk4.Rectangle: ...
@@ -443,18 +381,6 @@ class X11Surface(_Gdk4.Surface):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(_Gdk4.Surface.Props):
-        cursor: _Gdk4.Cursor | None
-        display: _Gdk4.Display
-        frame_clock: _Gdk4.FrameClock
-        height: int
-        mapped: bool
-        scale: float
-        scale_factor: int
-        width: int
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,

--- a/src/gi-stubs/repository/Gio.pyi
+++ b/src/gi-stubs/repository/Gio.pyi
@@ -3,6 +3,7 @@ from typing import Final
 from typing import Generic
 from typing import overload
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -989,16 +990,20 @@ class Application(GObject.Object, ActionGroup, ActionMap):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
+        action_group: ActionGroup | None
         application_id: str | None
         flags: ApplicationFlags
         inactivity_timeout: int
-        is_busy: bool
-        is_registered: bool
-        is_remote: bool
+        @property
+        def is_busy(self) -> bool: ...
+        @property
+        def is_registered(self) -> bool: ...
+        @property
+        def is_remote(self) -> bool: ...
         resource_base_path: str | None
         version: str | None
-        action_group: ActionGroup | None
 
     @property
     def props(self) -> Props: ...
@@ -1178,11 +1183,10 @@ class ApplicationCommandLine(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        is_remote: bool
-        arguments: GLib.Variant
-        options: GLib.Variant
-        platform_data: GLib.Variant
+        @property
+        def is_remote(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -1333,10 +1337,9 @@ class BufferedInputStream(FilterInputStream, Seekable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(FilterInputStream.Props):
         buffer_size: int
-        base_stream: InputStream
-        close_base_stream: bool
 
     @property
     def props(self) -> Props: ...
@@ -1424,11 +1427,10 @@ class BufferedOutputStream(FilterOutputStream, Seekable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(FilterOutputStream.Props):
         auto_grow: bool
         buffer_size: int
-        base_stream: OutputStream
-        close_base_stream: bool
 
     @property
     def props(self) -> Props: ...
@@ -1485,8 +1487,10 @@ class BytesIcon(GObject.Object, Icon, LoadableIcon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        bytes: GLib.Bytes
+        @property
+        def bytes(self) -> GLib.Bytes: ...
 
     @property
     def props(self) -> Props: ...
@@ -1569,9 +1573,12 @@ class CharsetConverter(GObject.Object, Converter, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        from_charset: str
-        to_charset: str
+        @property
+        def from_charset(self) -> str: ...
+        @property
+        def to_charset(self) -> str: ...
         use_fallback: bool
 
     @property
@@ -1654,10 +1661,10 @@ class ConverterInputStream(FilterInputStream, PollableInputStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(FilterInputStream.Props):
-        converter: Converter
-        base_stream: InputStream
-        close_base_stream: bool
+        @property
+        def converter(self) -> Converter: ...
 
     @property
     def props(self) -> Props: ...
@@ -1712,10 +1719,10 @@ class ConverterOutputStream(FilterOutputStream, PollableOutputStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(FilterOutputStream.Props):
-        converter: Converter
-        base_stream: OutputStream
-        close_base_stream: bool
+        @property
+        def converter(self) -> Converter: ...
 
     @property
     def props(self) -> Props: ...
@@ -1896,16 +1903,21 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        capabilities: DBusCapabilityFlags
-        closed: bool
+        @property
+        def capabilities(self) -> DBusCapabilityFlags: ...
+        @property
+        def closed(self) -> bool: ...
         exit_on_close: bool
-        flags: DBusConnectionFlags
-        guid: str
-        stream: IOStream
-        unique_name: str | None
-        address: str
-        authentication_observer: DBusAuthObserver
+        @property
+        def flags(self) -> DBusConnectionFlags: ...
+        @property
+        def guid(self) -> str: ...
+        @property
+        def stream(self) -> IOStream: ...
+        @property
+        def unique_name(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -2215,6 +2227,7 @@ class DBusInterfaceSkeleton(GObject.Object, DBusInterface):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         g_flags: DBusInterfaceSkeletonFlags
 
@@ -2329,8 +2342,10 @@ class DBusMessage(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        locked: bool
+        @property
+        def locked(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -2559,16 +2574,24 @@ class DBusObjectManagerClient(
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        connection: DBusConnection
-        flags: DBusObjectManagerClientFlags
-        get_proxy_type_destroy_notify: None
-        get_proxy_type_func: None
-        get_proxy_type_user_data: None
-        name: str
-        name_owner: str | None
-        object_path: str
-        bus_type: BusType
+        @property
+        def connection(self) -> DBusConnection: ...
+        @property
+        def flags(self) -> DBusObjectManagerClientFlags: ...
+        @property
+        def get_proxy_type_destroy_notify(self) -> None: ...
+        @property
+        def get_proxy_type_func(self) -> None: ...
+        @property
+        def get_proxy_type_user_data(self) -> None: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def name_owner(self) -> str | None: ...
+        @property
+        def object_path(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -2741,9 +2764,11 @@ class DBusObjectManagerServer(GObject.Object, DBusObjectManager):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         connection: DBusConnection | None
-        object_path: str
+        @property
+        def object_path(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -2800,9 +2825,12 @@ class DBusObjectProxy(GObject.Object, DBusObject):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        g_connection: DBusConnection
-        g_object_path: str
+        @property
+        def g_connection(self) -> DBusConnection: ...
+        @property
+        def g_object_path(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -2856,6 +2884,7 @@ class DBusObjectSkeleton(GObject.Object, DBusObject):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         g_object_path: str
 
@@ -3026,16 +3055,22 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        g_connection: DBusConnection
+        @property
+        def g_connection(self) -> DBusConnection: ...
         g_default_timeout: int
-        g_flags: DBusProxyFlags
+        @property
+        def g_flags(self) -> DBusProxyFlags: ...
         g_interface_info: DBusInterfaceInfo
-        g_interface_name: str
-        g_name: str
-        g_name_owner: str
-        g_object_path: str
-        g_bus_type: BusType
+        @property
+        def g_interface_name(self) -> str: ...
+        @property
+        def g_name(self) -> str: ...
+        @property
+        def g_name_owner(self) -> str: ...
+        @property
+        def g_object_path(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -3215,13 +3250,20 @@ class DBusServer(GObject.Object, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        active: bool
-        address: str
-        authentication_observer: DBusAuthObserver
-        client_address: str
-        flags: DBusServerFlags
-        guid: str
+        @property
+        def active(self) -> bool: ...
+        @property
+        def address(self) -> str: ...
+        @property
+        def authentication_observer(self) -> DBusAuthObserver: ...
+        @property
+        def client_address(self) -> str: ...
+        @property
+        def flags(self) -> DBusServerFlags: ...
+        @property
+        def guid(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -3308,12 +3350,10 @@ class DataInputStream(BufferedInputStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(BufferedInputStream.Props):
         byte_order: DataStreamByteOrder
         newline_type: DataStreamNewlineType
-        buffer_size: int
-        base_stream: InputStream
-        close_base_stream: bool
 
     @property
     def props(self) -> Props: ...
@@ -3330,7 +3370,10 @@ class DataInputStream(BufferedInputStream):
         base_stream: InputStream = ...,
         close_base_stream: bool = ...,
     ) -> None: ...
-    def __iter__(self): ...  # FIXME: Override is missing typing annotation
+    # override
+    def __iter__(self) -> Self: ...
+    # override
+    def __next__(self) -> str: ...
     def get_byte_order(self) -> DataStreamByteOrder: ...
     def get_newline_type(self) -> DataStreamNewlineType: ...
     @classmethod
@@ -3422,10 +3465,9 @@ class DataOutputStream(FilterOutputStream, Seekable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(FilterOutputStream.Props):
         byte_order: DataStreamByteOrder
-        base_stream: OutputStream
-        close_base_stream: bool
 
     @property
     def props(self) -> Props: ...
@@ -3565,8 +3607,10 @@ class DebugControllerDBus(GObject.Object, DebugController, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        connection: DBusConnection
+        @property
+        def connection(self) -> DBusConnection: ...
         debug_enabled: bool
 
     @property
@@ -3932,9 +3976,12 @@ class Emblem(GObject.Object, Icon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        icon: GObject.Object
-        origin: EmblemOrigin
+        @property
+        def icon(self) -> GObject.Object: ...
+        @property
+        def origin(self) -> EmblemOrigin: ...
 
     @property
     def props(self) -> Props: ...
@@ -3968,8 +4015,10 @@ class EmblemedIcon(GObject.Object, Icon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        gicon: Icon
+        @property
+        def gicon(self) -> Icon: ...
 
     @property
     def props(self) -> Props: ...
@@ -4617,17 +4666,15 @@ class FileEnumerator(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GObject.Object.Props):
-        container: File
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> GObject.Object: ...
     @property
     def priv(self) -> FileEnumeratorPrivate: ...
     def __init__(self, *, container: File = ...) -> None: ...
-    def __iter__(self): ...  # FIXME: Override is missing typing annotation
+    # override
+    def __iter__(self) -> Self: ...
+    # override
+    def __next__(self) -> FileInfo: ...
     def close(self, cancellable: Cancellable | None = None) -> bool: ...
     def close_async(
         self,
@@ -4724,13 +4771,6 @@ class FileIOStream(IOStream, Seekable):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(IOStream.Props):
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> IOStream: ...
     @property
@@ -4825,8 +4865,10 @@ class FileIcon(GObject.Object, Icon, LoadableIcon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        file: File
+        @property
+        def file(self) -> File: ...
 
     @property
     def props(self) -> Props: ...
@@ -5299,8 +5341,10 @@ class FileMonitor(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        cancelled: bool
+        @property
+        def cancelled(self) -> bool: ...
         rate_limit: int
 
     @property
@@ -5486,8 +5530,10 @@ class FilterInputStream(InputStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(InputStream.Props):
-        base_stream: InputStream
+        @property
+        def base_stream(self) -> InputStream: ...
         close_base_stream: bool
 
     @property
@@ -5531,9 +5577,12 @@ class FilterOutputStream(OutputStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(OutputStream.Props):
-        base_stream: OutputStream
-        close_base_stream: bool
+        @property
+        def base_stream(self) -> OutputStream: ...
+        @property
+        def close_base_stream(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -5627,10 +5676,14 @@ class IOStream(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
+        @property
+        def closed(self) -> bool: ...
+        @property
+        def input_stream(self) -> InputStream: ...
+        @property
+        def output_stream(self) -> OutputStream: ...
 
     @property
     def props(self) -> Props: ...
@@ -5772,21 +5825,36 @@ class InetAddress(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        bytes: None
-        family: SocketFamily
-        flowinfo: int
-        is_any: bool
-        is_link_local: bool
-        is_loopback: bool
-        is_mc_global: bool
-        is_mc_link_local: bool
-        is_mc_node_local: bool
-        is_mc_org_local: bool
-        is_mc_site_local: bool
-        is_multicast: bool
-        is_site_local: bool
-        scope_id: int
+        @property
+        def bytes(self) -> None: ...
+        @property
+        def family(self) -> SocketFamily: ...
+        @property
+        def flowinfo(self) -> int: ...
+        @property
+        def is_any(self) -> bool: ...
+        @property
+        def is_link_local(self) -> bool: ...
+        @property
+        def is_loopback(self) -> bool: ...
+        @property
+        def is_mc_global(self) -> bool: ...
+        @property
+        def is_mc_link_local(self) -> bool: ...
+        @property
+        def is_mc_node_local(self) -> bool: ...
+        @property
+        def is_mc_org_local(self) -> bool: ...
+        @property
+        def is_mc_site_local(self) -> bool: ...
+        @property
+        def is_multicast(self) -> bool: ...
+        @property
+        def is_site_local(self) -> bool: ...
+        @property
+        def scope_id(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -5869,9 +5937,11 @@ class InetAddressMask(GObject.Object, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         address: InetAddress
-        family: SocketFamily
+        @property
+        def family(self) -> SocketFamily: ...
         length: int
 
     @property
@@ -5930,12 +6000,16 @@ class InetSocketAddress(SocketAddress):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketAddress.Props):
-        address: InetAddress
-        flowinfo: int
-        port: int
-        scope_id: int
-        family: SocketFamily
+        @property
+        def address(self) -> InetAddress: ...
+        @property
+        def flowinfo(self) -> int: ...
+        @property
+        def port(self) -> int: ...
+        @property
+        def scope_id(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -6412,10 +6486,14 @@ class MemoryOutputStream(OutputStream, PollableOutputStream, Seekable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(OutputStream.Props):
-        data: None | None
-        data_size: int
-        size: int
+        @property
+        def data(self) -> None | None: ...
+        @property
+        def data_size(self) -> int: ...
+        @property
+        def size(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -6878,6 +6956,7 @@ class MountOperation(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         anonymous: bool
         choice: int
@@ -6994,11 +7073,6 @@ class NativeSocketAddress(SocketAddress):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(SocketAddress.Props):
-        family: SocketFamily
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> SocketAddress: ...
     @property
@@ -7082,10 +7156,14 @@ class NetworkAddress(GObject.Object, SocketConnectable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        hostname: str
-        port: int
-        scheme: str | None
+        @property
+        def hostname(self) -> str: ...
+        @property
+        def port(self) -> int: ...
+        @property
+        def scheme(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -7186,11 +7264,15 @@ class NetworkService(GObject.Object, SocketConnectable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        domain: str
-        protocol: str
+        @property
+        def domain(self) -> str: ...
+        @property
+        def protocol(self) -> str: ...
         scheme: str
-        service: str
+        @property
+        def service(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -7536,10 +7618,14 @@ class Permission(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        allowed: bool
-        can_acquire: bool
-        can_release: bool
+        @property
+        def allowed(self) -> bool: ...
+        @property
+        def can_acquire(self) -> bool: ...
+        @property
+        def can_release(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -7742,15 +7828,20 @@ class PropertyAction(GObject.Object, Action):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        enabled: bool
-        invert_boolean: bool
-        name: str
-        parameter_type: GLib.VariantType
-        state: GLib.Variant
-        state_type: GLib.VariantType
-        object: GObject.Object
-        property_name: str
+        @property
+        def enabled(self) -> bool: ...
+        @property
+        def invert_boolean(self) -> bool: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def parameter_type(self) -> GLib.VariantType: ...
+        @property
+        def state(self) -> GLib.Variant: ...
+        @property
+        def state_type(self) -> GLib.VariantType: ...
 
     @property
     def props(self) -> Props: ...
@@ -7825,19 +7916,22 @@ class ProxyAddress(InetSocketAddress):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(InetSocketAddress.Props):
-        destination_hostname: str
-        destination_port: int
-        destination_protocol: str
-        password: str | None
-        protocol: str
-        uri: str | None
-        username: str | None
-        address: InetAddress
-        flowinfo: int
-        port: int
-        scope_id: int
-        family: SocketFamily
+        @property
+        def destination_hostname(self) -> str: ...
+        @property
+        def destination_port(self) -> int: ...
+        @property
+        def destination_protocol(self) -> str: ...
+        @property
+        def password(self) -> str | None: ...
+        @property
+        def protocol(self) -> str: ...
+        @property
+        def uri(self) -> str | None: ...
+        @property
+        def username(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -7909,11 +8003,15 @@ class ProxyAddressEnumerator(SocketAddressEnumerator):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketAddressEnumerator.Props):
-        connectable: SocketConnectable
-        default_port: int
+        @property
+        def connectable(self) -> SocketConnectable: ...
+        @property
+        def default_port(self) -> int: ...
         proxy_resolver: ProxyResolver
-        uri: str
+        @property
+        def uri(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -8063,6 +8161,7 @@ class Resolver(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         timeout: int
 
@@ -8370,14 +8469,22 @@ class Settings(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        backend: SettingsBackend
-        delay_apply: bool
-        has_unapplied: bool
-        path: str
-        schema: str
-        schema_id: str
-        settings_schema: SettingsSchema
+        @property
+        def backend(self) -> SettingsBackend: ...
+        @property
+        def delay_apply(self) -> bool: ...
+        @property
+        def has_unapplied(self) -> bool: ...
+        @property
+        def path(self) -> str: ...
+        @property
+        def schema(self) -> str: ...
+        @property
+        def schema_id(self) -> str: ...
+        @property
+        def settings_schema(self) -> SettingsSchema: ...
 
     @property
     def props(self) -> Props: ...
@@ -8658,12 +8765,16 @@ class SimpleAction(GObject.Object, Action):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         enabled: bool
-        name: str
-        parameter_type: GLib.VariantType
+        @property
+        def name(self) -> str: ...
+        @property
+        def parameter_type(self) -> GLib.VariantType: ...
         state: GLib.Variant
-        state_type: GLib.VariantType
+        @property
+        def state_type(self) -> GLib.VariantType: ...
 
     @property
     def props(self) -> Props: ...
@@ -8806,10 +8917,12 @@ class SimpleIOStream(IOStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(IOStream.Props):
-        input_stream: InputStream
-        output_stream: OutputStream
-        closed: bool
+        @property
+        def input_stream(self) -> InputStream: ...
+        @property
+        def output_stream(self) -> OutputStream: ...
 
     @property
     def props(self) -> Props: ...
@@ -8840,13 +8953,6 @@ class SimplePermission(Permission):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Permission.Props):
-        allowed: bool
-        can_acquire: bool
-        can_release: bool
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls, allowed: bool) -> SimplePermission: ...
 
@@ -8867,6 +8973,7 @@ class SimpleProxyResolver(GObject.Object, ProxyResolver):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         default_proxy: str | None
         ignore_hosts: list[str]
@@ -8932,21 +9039,28 @@ class Socket(GObject.Object, DatagramBased, Initable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         blocking: bool
         broadcast: bool
-        family: SocketFamily
-        fd: int
+        @property
+        def family(self) -> SocketFamily: ...
+        @property
+        def fd(self) -> int: ...
         keepalive: bool
         listen_backlog: int
-        local_address: SocketAddress
+        @property
+        def local_address(self) -> SocketAddress: ...
         multicast_loopback: bool
         multicast_ttl: int
-        protocol: SocketProtocol
-        remote_address: SocketAddress
+        @property
+        def protocol(self) -> SocketProtocol: ...
+        @property
+        def remote_address(self) -> SocketAddress: ...
         timeout: int
         ttl: int
-        type: SocketType
+        @property
+        def type(self) -> SocketType: ...
 
     @property
     def props(self) -> Props: ...
@@ -9121,8 +9235,10 @@ class SocketAddress(GObject.Object, SocketConnectable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        family: SocketFamily
+        @property
+        def family(self) -> SocketFamily: ...
 
     @property
     def props(self) -> Props: ...
@@ -9250,12 +9366,13 @@ class SocketClient(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         enable_proxy: bool
         family: SocketFamily
         local_address: SocketAddress | None
         protocol: SocketProtocol
-        proxy_resolver: ProxyResolver
+        proxy_resolver: ProxyResolver | None
         timeout: int
         tls: bool
         tls_validation_flags: TlsCertificateFlags
@@ -9430,11 +9547,10 @@ class SocketConnection(IOStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(IOStream.Props):
-        socket: Socket
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
+        @property
+        def socket(self) -> Socket: ...
 
     @property
     def props(self) -> Props: ...
@@ -9553,6 +9669,7 @@ class SocketListener(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         listen_backlog: int
 
@@ -9654,9 +9771,9 @@ class SocketService(SocketListener):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketListener.Props):
         active: bool
-        listen_backlog: int
 
     @property
     def props(self) -> Props: ...
@@ -9752,12 +9869,6 @@ class Subprocess(GObject.Object, Initable):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GObject.Object.Props):
-        argv: list[str]
-        flags: SubprocessFlags
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, argv: Sequence[str] = ..., flags: SubprocessFlags = ...
     ) -> None: ...
@@ -9835,11 +9946,6 @@ class SubprocessLauncher(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GObject.Object.Props):
-        flags: SubprocessFlags
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, flags: SubprocessFlags = ...) -> None: ...
     def close(self) -> None: ...
     def getenv(self, variable: str) -> str | None: ...
@@ -9876,8 +9982,10 @@ class Task(GObject.Object, AsyncResult):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        completed: bool
+        @property
+        def completed(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -9971,12 +10079,9 @@ class TcpConnection(SocketConnection):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketConnection.Props):
         graceful_disconnect: bool
-        socket: Socket
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
 
     @property
     def props(self) -> Props: ...
@@ -10031,13 +10136,10 @@ class TcpWrapperConnection(TcpConnection):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(TcpConnection.Props):
-        base_io_stream: IOStream
-        graceful_disconnect: bool
-        socket: Socket
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
+        @property
+        def base_io_stream(self) -> IOStream: ...
 
     @property
     def props(self) -> Props: ...
@@ -10086,8 +10188,10 @@ class TestDBus(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        flags: TestDBusFlags
+        @property
+        def flags(self) -> TestDBusFlags: ...
 
     @property
     def props(self) -> Props: ...
@@ -10124,10 +10228,12 @@ class ThemedIcon(GObject.Object, Icon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        names: list[str]
-        use_default_fallbacks: bool
-        name: str
+        @property
+        def names(self) -> list[str]: ...
+        @property
+        def use_default_fallbacks(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -10170,11 +10276,6 @@ class ThreadedResolver(Resolver):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Resolver.Props):
-        timeout: int
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, timeout: int = ...) -> None: ...
 
 class ThreadedResolverClass(_gi.Struct):
@@ -10220,10 +10321,10 @@ class ThreadedSocketService(SocketService):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketService.Props):
-        max_threads: int
-        active: bool
-        listen_backlog: int
+        @property
+        def max_threads(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -10342,22 +10443,34 @@ class TlsCertificate(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        certificate: bytes
-        certificate_pem: str
-        dns_names: list[None] | None
-        ip_addresses: list[None] | None
-        issuer: TlsCertificate | None
-        issuer_name: str | None
-        not_valid_after: GLib.DateTime | None
-        not_valid_before: GLib.DateTime | None
-        pkcs11_uri: str
-        private_key: bytes
-        private_key_pem: str
-        private_key_pkcs11_uri: str
-        subject_name: str | None
-        password: str
-        pkcs12_data: bytes
+        @property
+        def certificate(self) -> bytes: ...
+        @property
+        def certificate_pem(self) -> str: ...
+        @property
+        def dns_names(self) -> list[None] | None: ...
+        @property
+        def ip_addresses(self) -> list[None] | None: ...
+        @property
+        def issuer(self) -> TlsCertificate | None: ...
+        @property
+        def issuer_name(self) -> str | None: ...
+        @property
+        def not_valid_after(self) -> GLib.DateTime | None: ...
+        @property
+        def not_valid_before(self) -> GLib.DateTime | None: ...
+        @property
+        def pkcs11_uri(self) -> str: ...
+        @property
+        def private_key(self) -> bytes: ...
+        @property
+        def private_key_pem(self) -> str: ...
+        @property
+        def private_key_pkcs11_uri(self) -> str: ...
+        @property
+        def subject_name(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -10510,23 +10623,27 @@ class TlsConnection(IOStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(IOStream.Props):
         advertised_protocols: list[str] | None
-        base_io_stream: IOStream
+        @property
+        def base_io_stream(self) -> IOStream: ...
         certificate: TlsCertificate | None
-        ciphersuite_name: str | None
+        @property
+        def ciphersuite_name(self) -> str | None: ...
         database: TlsDatabase | None
         interaction: TlsInteraction | None
-        negotiated_protocol: str | None
-        peer_certificate: TlsCertificate | None
-        peer_certificate_errors: TlsCertificateFlags
-        protocol_version: TlsProtocolVersion
+        @property
+        def negotiated_protocol(self) -> str | None: ...
+        @property
+        def peer_certificate(self) -> TlsCertificate | None: ...
+        @property
+        def peer_certificate_errors(self) -> TlsCertificateFlags: ...
+        @property
+        def protocol_version(self) -> TlsProtocolVersion: ...
         rehandshake_mode: TlsRehandshakeMode
         require_close_notify: bool
         use_system_certdb: bool
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
 
     @property
     def props(self) -> Props: ...
@@ -11069,6 +11186,7 @@ class TlsPassword(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         description: str
         flags: TlsPasswordFlags
@@ -11175,14 +11293,6 @@ class UnixConnection(SocketConnection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(SocketConnection.Props):
-        socket: Socket
-        closed: bool
-        input_stream: InputStream
-        output_stream: OutputStream
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> SocketConnection: ...
     @property
@@ -11240,8 +11350,10 @@ class UnixCredentialsMessage(SocketControlMessage):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketControlMessage.Props):
-        credentials: Credentials
+        @property
+        def credentials(self) -> Credentials: ...
 
     @property
     def props(self) -> Props: ...
@@ -11358,12 +11470,16 @@ class UnixSocketAddress(SocketAddress):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(SocketAddress.Props):
-        abstract: bool
-        address_type: UnixSocketAddressType
-        path: str
-        path_as_array: bytes
-        family: SocketFamily
+        @property
+        def abstract(self) -> bool: ...
+        @property
+        def address_type(self) -> UnixSocketAddressType: ...
+        @property
+        def path(self) -> str: ...
+        @property
+        def path_as_array(self) -> bytes: ...
 
     @property
     def props(self) -> Props: ...
@@ -11745,10 +11861,13 @@ class ZlibCompressor(GObject.Object, Converter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         file_info: FileInfo | None
-        format: ZlibCompressorFormat
-        level: int
+        @property
+        def format(self) -> ZlibCompressorFormat: ...
+        @property
+        def level(self) -> int: ...
         os: int
 
     @property
@@ -11797,9 +11916,12 @@ class ZlibDecompressor(GObject.Object, Converter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        file_info: FileInfo | None
-        format: ZlibCompressorFormat
+        @property
+        def file_info(self) -> FileInfo | None: ...
+        @property
+        def format(self) -> ZlibCompressorFormat: ...
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/GioUnix.pyi
+++ b/src/gi-stubs/repository/GioUnix.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -71,8 +72,10 @@ class DesktopAppInfo(GObject.Object, Gio.AppInfo):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        filename: str | None
+        @property
+        def filename(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -182,8 +185,10 @@ class FDMessage(Gio.SocketControlMessage):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.SocketControlMessage.Props):
-        fd_list: Gio.UnixFDList
+        @property
+        def fd_list(self) -> Gio.UnixFDList: ...
 
     @property
     def props(self) -> Props: ...
@@ -253,9 +258,11 @@ class InputStream(Gio.InputStream, Gio.PollableInputStream, FileDescriptorBased)
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.InputStream.Props):
         close_fd: bool
-        fd: int
+        @property
+        def fd(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -366,9 +373,11 @@ class OutputStream(Gio.OutputStream, Gio.PollableOutputStream, FileDescriptorBas
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.OutputStream.Props):
         close_fd: bool
-        fd: int
+        @property
+        def fd(self) -> int: ...
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/Gly.pyi
+++ b/src/gi-stubs/repository/Gly.pyi
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -48,8 +49,10 @@ class Creator(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        mime_type: str
+        @property
+        def mime_type(self) -> str: ...
         sandbox_selector: SandboxSelector
 
     @property
@@ -110,8 +113,10 @@ class EncodedImage(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        data: GLib.Bytes
+        @property
+        def data(self) -> GLib.Bytes: ...
 
     @property
     def props(self) -> Props: ...
@@ -179,10 +184,13 @@ class FrameRequest(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         loop_animation: bool
-        scale_height: int
-        scale_width: int
+        @property
+        def scale_height(self) -> int: ...
+        @property
+        def scale_width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -276,14 +284,18 @@ class Loader(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         apply_transformation: bool
-        bytes: GLib.Bytes
+        @property
+        def bytes(self) -> GLib.Bytes: ...
         cancellable: Gio.Cancellable
-        file: Gio.File
+        @property
+        def file(self) -> Gio.File: ...
         memory_format_selection: MemoryFormatSelection
         sandbox_selector: SandboxSelector
-        stream: Gio.InputStream
+        @property
+        def stream(self) -> Gio.InputStream: ...
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/Gsk.pyi
+++ b/src/gi-stubs/repository/Gsk.pyi
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -95,12 +96,6 @@ class BroadwayRenderer(Renderer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Renderer.Props):
-        realized: bool
-        surface: _Gdk4.Surface | None
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> BroadwayRenderer: ...
 
@@ -138,12 +133,6 @@ class CairoRenderer(Renderer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Renderer.Props):
-        realized: bool
-        surface: _Gdk4.Surface | None
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> CairoRenderer: ...
 
@@ -361,12 +350,6 @@ class GLRenderer(Renderer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Renderer.Props):
-        realized: bool
-        surface: _Gdk4.Surface | None
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> GLRenderer: ...
 
@@ -391,9 +374,12 @@ class GLShader(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        resource: str | None
-        source: GLib.Bytes
+        @property
+        def resource(self) -> str | None: ...
+        @property
+        def source(self) -> GLib.Bytes: ...
 
     @property
     def props(self) -> Props: ...
@@ -542,12 +528,6 @@ class NglRenderer(Renderer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Renderer.Props):
-        realized: bool
-        surface: _Gdk4.Surface | None
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> NglRenderer: ...
 
@@ -807,9 +787,12 @@ class Renderer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        realized: bool
-        surface: _Gdk4.Surface | None
+        @property
+        def realized(self) -> bool: ...
+        @property
+        def surface(self) -> _Gdk4.Surface | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -1172,12 +1155,6 @@ class VulkanRenderer(Renderer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Renderer.Props):
-        realized: bool
-        surface: _Gdk4.Surface | None
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> VulkanRenderer: ...
 

--- a/src/gi-stubs/repository/Gst.pyi
+++ b/src/gi-stubs/repository/Gst.pyi
@@ -2,6 +2,7 @@ from typing import Any
 from typing import Final
 from typing import Generic
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -653,12 +654,6 @@ class Allocator(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -777,11 +772,10 @@ class Bin(Element, ChildProxy):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Element.Props):
         async_handling: bool
         message_forward: bool
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1070,12 +1064,6 @@ class BufferPool(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -1236,13 +1224,6 @@ class Bus(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-        enable_async: bool
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -1524,12 +1505,11 @@ class Clock(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         timeout: int
         window_size: int
         window_threshold: int
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1728,10 +1708,12 @@ class ControlBinding(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
-        name: str
-        object: Object
-        parent: Object | None
+        @property
+        def name(self) -> str: ...
+        @property
+        def object(self) -> Object: ...
 
     @property
     def props(self) -> Props: ...
@@ -1808,12 +1790,6 @@ class ControlSource(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Object: ...
     @property
@@ -2004,13 +1980,16 @@ class Device(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
-        caps: Caps | None
-        device_class: str
-        display_name: str
-        properties: Structure | None
-        name: str | None
-        parent: Object | None
+        @property
+        def caps(self) -> Caps | None: ...
+        @property
+        def device_class(self) -> str: ...
+        @property
+        def display_name(self) -> str: ...
+        @property
+        def properties(self) -> Structure | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -2081,10 +2060,9 @@ class DeviceMonitor(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         show_all: bool
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -2149,12 +2127,6 @@ class DeviceProvider(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Object: ...
     @property
@@ -2243,12 +2215,6 @@ class DeviceProviderFactory(PluginFeature):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(PluginFeature.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     @staticmethod
     def find(name: str) -> DeviceProviderFactory | None: ...
@@ -2304,12 +2270,6 @@ class DynamicTypeFactory(PluginFeature):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(PluginFeature.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     @staticmethod
     def load(factoryname: str) -> type[Any]: ...
@@ -2343,12 +2303,6 @@ class Element(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -2663,12 +2617,6 @@ class ElementFactory(PluginFeature):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(PluginFeature.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     def can_sink_all_caps(self, caps: Caps) -> bool: ...
     def can_sink_any_caps(self, caps: Caps) -> bool: ...
@@ -2882,7 +2830,11 @@ class FlagSet:
     @staticmethod
     def register(flags_type: type[Any]) -> type[Any]: ...
 
-class Float(float): ...
+class Float(float):
+    """
+    A wrapper to force conversion to G_TYPE_FLOAT instead of G_TYPE_DOUBLE when
+    used in e.g. Gst.ValueArray.
+    """
 
 class FormatDefinition(_gi.Struct):
     """
@@ -2971,16 +2923,6 @@ class GhostPad(ProxyPad):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ProxyPad.Props):
-        caps: Caps
-        direction: PadDirection
-        offset: int
-        template: PadTemplate
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def pad(self) -> ProxyPad: ...
     @property
@@ -3568,12 +3510,6 @@ class MetaFactory(PluginFeature):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(PluginFeature.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     @staticmethod
     def load(factoryname: str) -> MetaInfo: ...
@@ -3688,6 +3624,7 @@ class Object(GObject.InitiallyUnowned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         name: str | None
         parent: Object | None
@@ -3808,13 +3745,14 @@ class Pad(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
-        caps: Caps
-        direction: PadDirection
+        @property
+        def caps(self) -> Caps: ...
+        @property
+        def direction(self) -> PadDirection: ...
         offset: int
         template: PadTemplate
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -4154,14 +4092,18 @@ class PadTemplate(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
-        caps: Caps
-        direction: PadDirection
-        gtype: type[Any]
-        name_template: str
-        presence: PadPresence
-        name: str | None
-        parent: Object | None
+        @property
+        def caps(self) -> Caps: ...
+        @property
+        def direction(self) -> PadDirection: ...
+        @property
+        def gtype(self) -> type[Any]: ...
+        @property
+        def name_template(self) -> str: ...
+        @property
+        def presence(self) -> PadPresence: ...
 
     @property
     def props(self) -> Props: ...
@@ -4226,8 +4168,23 @@ class PadTemplateClass(_gi.Struct):
     @property
     def pad_created(self) -> Callable[[PadTemplate, Pad], None]: ...
 
-class ParamArray(GObject.ParamSpec): ...
-class ParamFraction(GObject.ParamSpec): ...
+class ParamArray(GObject.ParamSpec):
+    """
+    :Constructors:
+
+    ::
+
+        ParamArray(**properties)
+    """
+
+class ParamFraction(GObject.ParamSpec):
+    """
+    :Constructors:
+
+    ::
+
+        ParamFraction(**properties)
+    """
 
 class ParamSpecArray(_gi.Struct):
     """
@@ -4345,14 +4302,11 @@ class Pipeline(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         auto_flush_bus: bool
         delay: int
         latency: int
-        async_handling: bool
-        message_forward: bool
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -4427,12 +4381,6 @@ class Plugin(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     def add_dependency(
         self,
@@ -4546,12 +4494,6 @@ class PluginFeature(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     def check_version(self, min_major: int, min_minor: int, min_micro: int) -> bool: ...
     def get_plugin(self) -> Plugin | None: ...
@@ -4728,16 +4670,6 @@ class ProxyPad(Pad):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Pad.Props):
-        caps: Caps
-        direction: PadDirection
-        offset: int
-        template: PadTemplate
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def pad(self) -> Pad: ...
     @property
@@ -5004,12 +4936,6 @@ class Registry(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -5176,12 +5102,6 @@ class SharedTaskPool(TaskPool):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(TaskPool.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> TaskPool: ...
     @property
@@ -5270,14 +5190,14 @@ class Stream(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         caps: Caps | None
         stream_flags: StreamFlags
-        stream_id: str | None
+        @property
+        def stream_id(self) -> str | None: ...
         stream_type: StreamType
         tags: TagList | None
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -5357,10 +5277,9 @@ class StreamCollection(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         upstream_id: str | None
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -5577,13 +5496,9 @@ class SystemClock(Clock):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Clock.Props):
         clock_type: ClockType
-        timeout: int
-        window_size: int
-        window_threshold: int
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -5738,12 +5653,6 @@ class Task(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -5822,12 +5731,6 @@ class TaskPool(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Object: ...
     @property
@@ -5978,10 +5881,9 @@ class Tracer(Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Object.Props):
         params: str
-        name: str | None
-        parent: Object | None
 
     @property
     def props(self) -> Props: ...
@@ -6032,12 +5934,6 @@ class TracerFactory(PluginFeature):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(PluginFeature.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     @staticmethod
     def get_list() -> list[TracerFactory]: ...
@@ -6068,12 +5964,6 @@ class TracerRecord(Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Object.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
 
 class TracerRecordClass(_gi.Struct): ...
@@ -6125,12 +6015,6 @@ class TypeFindFactory(PluginFeature):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(PluginFeature.Props):
-        name: str | None
-        parent: Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Object = ...) -> None: ...
     def call_function(self, find: TypeFind) -> None: ...
     def get_caps(self) -> Caps | None: ...

--- a/src/gi-stubs/repository/GstApp.pyi
+++ b/src/gi-stubs/repository/GstApp.pyi
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -114,37 +115,30 @@ class AppSink(GstBase.BaseSink, Gst.URIHandler):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.BaseSink.Props):
         buffer_list: bool
         caps: Gst.Caps | None
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
+        @property
+        def current_level_buffers(self) -> int: ...
+        @property
+        def current_level_bytes(self) -> int: ...
+        @property
+        def current_level_time(self) -> int: ...
         drop: bool
-        dropped: int
+        @property
+        def dropped(self) -> int: ...
         emit_signals: bool
-        eos: bool
+        @property
+        def eos(self) -> bool: ...
         leaky_type: AppLeakyType
         max_buffers: int
         max_bytes: int
         max_time: int
-        out: int
+        @property
+        def out(self) -> int: ...
         silent: bool
         wait_on_eos: bool
-        blocksize: int
-        enable_last_sample: bool
-        last_sample: Gst.Sample | None
-        max_bitrate: int
-        max_lateness: int
-        processing_deadline: int
-        qos: bool
-        render_delay: int
-        stats: Gst.Structure
-        sync: bool
-        throttle_time: int
-        ts_offset: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -371,13 +365,18 @@ class AppSrc(GstBase.BaseSrc, Gst.URIHandler):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.BaseSrc.Props):
         block: bool
         caps: Gst.Caps | None
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
-        dropped: int
+        @property
+        def current_level_buffers(self) -> int: ...
+        @property
+        def current_level_bytes(self) -> int: ...
+        @property
+        def current_level_time(self) -> int: ...
+        @property
+        def dropped(self) -> int: ...
         duration: int
         emit_signals: bool
         format: Gst.Format
@@ -390,17 +389,11 @@ class AppSrc(GstBase.BaseSrc, Gst.URIHandler):
         max_time: int
         min_latency: int
         min_percent: int
-        out: int
+        @property
+        def out(self) -> int: ...
         silent: bool
         size: int
         stream_type: AppStreamType
-        automatic_eos: bool
-        blocksize: int
-        do_timestamp: bool
-        num_buffers: int
-        typefind: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/GstAudio.pyi
+++ b/src/gi-stubs/repository/GstAudio.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -248,20 +249,15 @@ class AudioAggregator(GstBase.Aggregator):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.Aggregator.Props):
         alignment_threshold: int
         discont_wait: int
-        force_live: bool
+        @property
+        def force_live(self) -> bool: ...
         ignore_inactive_pads: bool
         output_buffer_duration: int
         output_buffer_duration_fraction: Gst.Fraction
-        emit_signals: bool
-        latency: int
-        min_upstream_latency: int
-        start_time: int
-        start_time_selection: GstBase.AggregatorStartTimeSelection
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -377,19 +373,9 @@ class AudioAggregatorConvertPad(AudioAggregatorPad):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(AudioAggregatorPad.Props):
         converter_config: Gst.Structure
-        qos_messages: bool
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
-        emit_signals: bool
-        caps: Gst.Caps
-        direction: Gst.PadDirection
-        offset: int
-        template: Gst.PadTemplate
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -476,18 +462,9 @@ class AudioAggregatorPad(GstBase.AggregatorPad):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.AggregatorPad.Props):
         qos_messages: bool
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
-        emit_signals: bool
-        caps: Gst.Caps
-        direction: Gst.PadDirection
-        offset: int
-        template: Gst.PadTemplate
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -608,6 +585,7 @@ class AudioBaseSink(GstBase.BaseSink):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.BaseSink.Props):
         alignment_threshold: int
         buffer_time: int
@@ -617,20 +595,6 @@ class AudioBaseSink(GstBase.BaseSink):
         latency_time: int
         provide_clock: bool
         slave_method: AudioBaseSinkSlaveMethod
-        blocksize: int
-        enable_last_sample: bool
-        last_sample: Gst.Sample | None
-        max_bitrate: int
-        max_lateness: int
-        processing_deadline: int
-        qos: bool
-        render_delay: int
-        stats: Gst.Structure
-        sync: bool
-        throttle_time: int
-        ts_offset: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -764,20 +728,16 @@ class AudioBaseSrc(GstBase.PushSrc):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.PushSrc.Props):
-        actual_buffer_time: int
-        actual_latency_time: int
+        @property
+        def actual_buffer_time(self) -> int: ...
+        @property
+        def actual_latency_time(self) -> int: ...
         buffer_time: int
         latency_time: int
         provide_clock: bool
         slave_method: AudioBaseSrcSlaveMethod
-        automatic_eos: bool
-        blocksize: int
-        do_timestamp: bool
-        num_buffers: int
-        typefind: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -920,17 +880,11 @@ class AudioCdSrc(GstBase.PushSrc, Gst.URIHandler):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.PushSrc.Props):
         device: str
         mode: AudioCdSrcMode
         track: int
-        automatic_eos: bool
-        blocksize: int
-        do_timestamp: bool
-        num_buffers: int
-        typefind: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1051,16 +1005,6 @@ class AudioClock(Gst.SystemClock):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gst.SystemClock.Props):
-        clock_type: Gst.ClockType
-        timeout: int
-        window_size: int
-        window_threshold: int
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def clock(self) -> Gst.SystemClock: ...
     @property
@@ -1179,13 +1123,12 @@ class AudioDecoder(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         max_errors: int
         min_latency: int
         plc: bool
         tolerance: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1376,13 +1319,13 @@ class AudioEncoder(Gst.Element, Gst.Preset):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         hard_resync: bool
-        mark_granule: bool
+        @property
+        def mark_granule(self) -> bool: ...
         perfect_timestamp: bool
         tolerance: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1545,13 +1488,6 @@ class AudioFilter(GstBase.BaseTransform):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GstBase.BaseTransform.Props):
-        qos: bool
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def basetransform(self) -> GstBase.BaseTransform: ...
     @property
@@ -1732,12 +1668,6 @@ class AudioRingBuffer(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gst.Object.Props):
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Gst.Object: ...
     @property
@@ -1972,32 +1902,6 @@ class AudioSink(AudioBaseSink):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(AudioBaseSink.Props):
-        alignment_threshold: int
-        buffer_time: int
-        can_activate_pull: bool
-        discont_wait: int
-        drift_tolerance: int
-        latency_time: int
-        provide_clock: bool
-        slave_method: AudioBaseSinkSlaveMethod
-        blocksize: int
-        enable_last_sample: bool
-        last_sample: Gst.Sample | None
-        max_bitrate: int
-        max_lateness: int
-        processing_deadline: int
-        qos: bool
-        render_delay: int
-        stats: Gst.Structure
-        sync: bool
-        throttle_time: int
-        ts_offset: int
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def element(self) -> AudioBaseSink: ...
     @property
@@ -2134,23 +2038,6 @@ class AudioSrc(AudioBaseSrc):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(AudioBaseSrc.Props):
-        actual_buffer_time: int
-        actual_latency_time: int
-        buffer_time: int
-        latency_time: int
-        provide_clock: bool
-        slave_method: AudioBaseSrcSlaveMethod
-        automatic_eos: bool
-        blocksize: int
-        do_timestamp: bool
-        num_buffers: int
-        typefind: bool
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def element(self) -> AudioBaseSrc: ...
     @property

--- a/src/gi-stubs/repository/GstBase.pyi
+++ b/src/gi-stubs/repository/GstBase.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -156,14 +157,13 @@ class Aggregator(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         emit_signals: bool
         latency: int
         min_upstream_latency: int
         start_time: int
         start_time_selection: AggregatorStartTimeSelection
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -370,17 +370,15 @@ class AggregatorPad(Gst.Pad):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Pad.Props):
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
+        @property
+        def current_level_buffers(self) -> int: ...
+        @property
+        def current_level_bytes(self) -> int: ...
+        @property
+        def current_level_time(self) -> int: ...
         emit_signals: bool
-        caps: Gst.Caps
-        direction: Gst.PadDirection
-        offset: int
-        template: Gst.PadTemplate
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -462,11 +460,10 @@ class BaseParse(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         disable_clip: bool
         disable_passthrough: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -653,21 +650,22 @@ class BaseSink(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         blocksize: int
         enable_last_sample: bool
-        last_sample: Gst.Sample | None
+        @property
+        def last_sample(self) -> Gst.Sample | None: ...
         max_bitrate: int
         max_lateness: int
         processing_deadline: int
         qos: bool
         render_delay: int
-        stats: Gst.Structure
+        @property
+        def stats(self) -> Gst.Structure: ...
         sync: bool
         throttle_time: int
         ts_offset: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -865,14 +863,13 @@ class BaseSrc(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         automatic_eos: bool
         blocksize: int
         do_timestamp: bool
         num_buffers: int
         typefind: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1057,10 +1054,9 @@ class BaseTransform(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         qos: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1470,12 +1466,6 @@ class CollectPads(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gst.Object.Props):
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> Gst.Object: ...
     @property
@@ -1577,10 +1567,14 @@ class DataQueue(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        current_level_bytes: int
-        current_level_time: int
-        current_level_visible: int
+        @property
+        def current_level_bytes(self) -> int: ...
+        @property
+        def current_level_time(self) -> int: ...
+        @property
+        def current_level_visible(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -1669,17 +1663,6 @@ class PushSrc(BaseSrc):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(BaseSrc.Props):
-        automatic_eos: bool
-        blocksize: int
-        do_timestamp: bool
-        num_buffers: int
-        typefind: bool
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> BaseSrc: ...
     def __init__(

--- a/src/gi-stubs/repository/GstPbutils.pyi
+++ b/src/gi-stubs/repository/GstPbutils.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -189,11 +190,10 @@ class AudioVisualizer(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         shade_amount: int
         shader: AudioVisualizerShader
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -267,6 +267,7 @@ class Discoverer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         timeout: int
         use_cache: bool
@@ -471,12 +472,6 @@ class EncodingAudioProfile(EncodingProfile):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EncodingProfile.Props):
-        element_properties: Gst.Structure | None
-        restriction_caps: Gst.Caps
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -514,12 +509,6 @@ class EncodingContainerProfile(EncodingProfile):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EncodingProfile.Props):
-        element_properties: Gst.Structure | None
-        restriction_caps: Gst.Caps
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -559,6 +548,7 @@ class EncodingProfile(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         element_properties: Gst.Structure | None
         restriction_caps: Gst.Caps
@@ -662,12 +652,6 @@ class EncodingVideoProfile(EncodingProfile):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EncodingProfile.Props):
-        element_properties: Gst.Structure | None
-        restriction_caps: Gst.Caps
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,

--- a/src/gi-stubs/repository/GstRtp.pyi
+++ b/src/gi-stubs/repository/GstRtp.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -373,27 +374,9 @@ class RTPBaseAudioPayload(RTPBasePayload):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(RTPBasePayload.Props):
         buffer_list: bool
-        auto_header_extension: bool
-        extensions: Gst.ValueArray
-        max_ptime: int
-        min_ptime: int
-        mtu: int
-        onvif_no_rate_control: bool
-        perfect_rtptime: bool
-        pt: int
-        ptime_multiple: int
-        scale_rtptime: bool
-        seqnum: int
-        seqnum_offset: int
-        source_info: bool
-        ssrc: int
-        stats: Gst.Structure
-        timestamp: int
-        timestamp_offset: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -495,14 +478,15 @@ class RTPBaseDepayload(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         auto_header_extension: bool
-        extensions: Gst.ValueArray
+        @property
+        def extensions(self) -> Gst.ValueArray: ...
         max_reorder: int
         source_info: bool
-        stats: Gst.Structure
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def stats(self) -> Gst.Structure: ...
 
     @property
     def props(self) -> Props: ...
@@ -637,9 +621,11 @@ class RTPBasePayload(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         auto_header_extension: bool
-        extensions: Gst.ValueArray
+        @property
+        def extensions(self) -> Gst.ValueArray: ...
         max_ptime: int
         min_ptime: int
         mtu: int
@@ -648,15 +634,16 @@ class RTPBasePayload(Gst.Element):
         pt: int
         ptime_multiple: int
         scale_rtptime: bool
-        seqnum: int
+        @property
+        def seqnum(self) -> int: ...
         seqnum_offset: int
         source_info: bool
         ssrc: int
-        stats: Gst.Structure
-        timestamp: int
+        @property
+        def stats(self) -> Gst.Structure: ...
+        @property
+        def timestamp(self) -> int: ...
         timestamp_offset: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -884,12 +871,6 @@ class RTPHeaderExtension(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gst.Element.Props):
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Gst.Element: ...
     def __init__(self, *, name: str | None = ..., parent: Gst.Object = ...) -> None: ...

--- a/src/gi-stubs/repository/GstRtspServer.pyi
+++ b/src/gi-stubs/repository/GstRtspServer.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -249,6 +250,7 @@ class RTSPClient(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         drop_backlog: bool
         mount_points: RTSPMountPoints | None
@@ -583,12 +585,14 @@ class RTSPMedia(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         bind_mcast_address: bool
         buffer_size: int
         clock: Gst.Clock | None
         dscp_qos: int
-        element: Gst.Element
+        @property
+        def element(self) -> Gst.Element: ...
         ensure_keyunit_on_start: bool
         ensure_keyunit_on_start_timeout: int
         eos_shutdown: bool
@@ -848,6 +852,7 @@ class RTSPMediaFactory(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         bind_mcast_address: bool
         buffer_size: int
@@ -1045,26 +1050,10 @@ class RTSPMediaFactoryURI(RTSPMediaFactory):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(RTSPMediaFactory.Props):
         uri: str
         use_gstpay: bool
-        bind_mcast_address: bool
-        buffer_size: int
-        clock: Gst.Clock | None
-        dscp_qos: int
-        enable_rtcp: bool
-        ensure_keyunit_on_start: bool
-        ensure_keyunit_on_start_timeout: int
-        eos_shutdown: bool
-        latency: int
-        launch: str | None
-        max_mcast_ttl: int
-        profiles: GstRtsp.RTSPProfile
-        protocols: GstRtsp.RTSPLowerTrans
-        shared: bool
-        stop_on_disconnect: bool
-        suspend_mode: RTSPSuspendMode
-        transport_mode: RTSPTransportMode
 
     @property
     def props(self) -> Props: ...
@@ -1207,14 +1196,6 @@ class RTSPOnvifClient(RTSPClient):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RTSPClient.Props):
-        drop_backlog: bool
-        mount_points: RTSPMountPoints | None
-        post_session_timeout: int
-        session_pool: RTSPSessionPool | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RTSPClient: ...
     def __init__(
@@ -1299,28 +1280,6 @@ class RTSPOnvifMedia(RTSPMedia):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RTSPMedia.Props):
-        bind_mcast_address: bool
-        buffer_size: int
-        clock: Gst.Clock | None
-        dscp_qos: int
-        element: Gst.Element
-        ensure_keyunit_on_start: bool
-        ensure_keyunit_on_start_timeout: int
-        eos_shutdown: bool
-        latency: int
-        max_mcast_ttl: int
-        profiles: GstRtsp.RTSPProfile
-        protocols: GstRtsp.RTSPLowerTrans
-        reusable: bool
-        shared: bool
-        stop_on_disconnect: bool
-        suspend_mode: RTSPSuspendMode
-        time_provider: bool | None
-        transport_mode: RTSPTransportMode
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RTSPMedia: ...
     @property
@@ -1416,27 +1375,6 @@ class RTSPOnvifMediaFactory(RTSPMediaFactory):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RTSPMediaFactory.Props):
-        bind_mcast_address: bool
-        buffer_size: int
-        clock: Gst.Clock | None
-        dscp_qos: int
-        enable_rtcp: bool
-        ensure_keyunit_on_start: bool
-        ensure_keyunit_on_start_timeout: int
-        eos_shutdown: bool
-        latency: int
-        launch: str | None
-        max_mcast_ttl: int
-        profiles: GstRtsp.RTSPProfile
-        protocols: GstRtsp.RTSPLowerTrans
-        shared: bool
-        stop_on_disconnect: bool
-        suspend_mode: RTSPSuspendMode
-        transport_mode: RTSPTransportMode
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RTSPMediaFactory: ...
     @property
@@ -1531,17 +1469,6 @@ class RTSPOnvifServer(RTSPServer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RTSPServer.Props):
-        address: str | None
-        backlog: int
-        bound_port: int
-        content_length_limit: int
-        mount_points: RTSPMountPoints | None
-        service: str
-        session_pool: RTSPSessionPool | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RTSPServer: ...
     def __init__(
@@ -1625,10 +1552,12 @@ class RTSPServer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         address: str | None
         backlog: int
-        bound_port: int
+        @property
+        def bound_port(self) -> int: ...
         content_length_limit: int
         mount_points: RTSPMountPoints | None
         service: str
@@ -1729,9 +1658,11 @@ class RTSPSession(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         extra_timeout: int
-        sessionid: str | None
+        @property
+        def sessionid(self) -> str | None: ...
         timeout: int
         timeout_always_visible: bool
 
@@ -1849,6 +1780,7 @@ class RTSPSessionPool(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         max_sessions: int
 
@@ -1922,6 +1854,7 @@ class RTSPStream(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         control: str | None
         profiles: GstRtsp.RTSPProfile
@@ -2077,8 +2010,10 @@ class RTSPStreamTransport(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        timed_out: bool
+        @property
+        def timed_out(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -2178,6 +2113,7 @@ class RTSPThreadPool(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         max_threads: int
 

--- a/src/gi-stubs/repository/GstVideo.pyi
+++ b/src/gi-stubs/repository/GstVideo.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -795,15 +796,10 @@ class VideoAggregator(GstBase.Aggregator):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.Aggregator.Props):
-        force_live: bool
-        emit_signals: bool
-        latency: int
-        min_upstream_latency: int
-        start_time: int
-        start_time_selection: GstBase.AggregatorStartTimeSelection
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def force_live(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -919,21 +915,9 @@ class VideoAggregatorConvertPad(VideoAggregatorPad):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(VideoAggregatorPad.Props):
         converter_config: Gst.Structure
-        max_last_buffer_repeat: int
-        repeat_after_eos: bool
-        zorder: int
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
-        emit_signals: bool
-        caps: Gst.Caps
-        direction: Gst.PadDirection
-        offset: int
-        template: Gst.PadTemplate
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1034,20 +1018,11 @@ class VideoAggregatorPad(GstBase.AggregatorPad):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.AggregatorPad.Props):
         max_last_buffer_repeat: int
         repeat_after_eos: bool
         zorder: int
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
-        emit_signals: bool
-        caps: Gst.Caps
-        direction: Gst.PadDirection
-        offset: int
-        template: Gst.PadTemplate
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1190,24 +1165,6 @@ class VideoAggregatorParallelConvertPad(VideoAggregatorConvertPad):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(VideoAggregatorConvertPad.Props):
-        converter_config: Gst.Structure
-        max_last_buffer_repeat: int
-        repeat_after_eos: bool
-        zorder: int
-        current_level_buffers: int
-        current_level_bytes: int
-        current_level_time: int
-        emit_signals: bool
-        caps: Gst.Caps
-        direction: Gst.PadDirection
-        offset: int
-        template: Gst.PadTemplate
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> VideoAggregatorConvertPad: ...
     def __init__(
@@ -1308,12 +1265,6 @@ class VideoBufferPool(Gst.BufferPool):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gst.BufferPool.Props):
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def bufferpool(self) -> Gst.BufferPool: ...
     @property
@@ -1552,6 +1503,7 @@ class VideoDecoder(Gst.Element):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         automatic_request_sync_point_flags: VideoDecoderRequestSyncPointFlags
         automatic_request_sync_points: bool
@@ -1559,8 +1511,6 @@ class VideoDecoder(Gst.Element):
         max_errors: int
         min_force_key_unit_interval: int
         qos: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -1742,7 +1692,11 @@ class VideoDecoderClass(_gi.Struct):
     def padding(self) -> list[None]: ...
 
 class VideoDecoderPrivate(_gi.Struct): ...
-class VideoDirection(GObject.GInterface, Protocol): ...
+
+class VideoDirection(GObject.GInterface, Protocol):
+    """
+    Interface GstVideoDirection
+    """
 
 class VideoDirectionInterface(_gi.Struct):
     """
@@ -1782,12 +1736,6 @@ class VideoDmabufPool(VideoBufferPool):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(VideoBufferPool.Props):
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, name: str | None = ..., parent: Gst.Object = ...) -> None: ...
     @classmethod
     def new(cls) -> VideoDmabufPool: ...
@@ -1836,11 +1784,10 @@ class VideoEncoder(Gst.Element, Gst.Preset):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Element.Props):
         min_force_key_unit_interval: int
         qos: bool
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -2004,13 +1951,6 @@ class VideoFilter(GstBase.BaseTransform):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GstBase.BaseTransform.Props):
-        qos: bool
-        name: str | None
-        parent: Gst.Object | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def element(self) -> GstBase.BaseTransform: ...
     @property
@@ -2345,7 +2285,14 @@ class VideoMetaTransformMatrix(_gi.Struct):
     def rectangle(self) -> tuple[bool, VideoRectangle]: ...
     def rectangle_clipped(self) -> tuple[bool, VideoRectangle]: ...
 
-class VideoMultiviewFlagsSet(Gst.FlagSet): ...
+class VideoMultiviewFlagsSet(Gst.FlagSet):
+    """
+    :Constructors:
+
+    ::
+
+        VideoMultiviewFlagsSet(**properties)
+    """
 
 class VideoOrientation(GObject.GInterface, Protocol):
     """
@@ -2661,22 +2608,9 @@ class VideoSink(GstBase.BaseSink):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GstBase.BaseSink.Props):
         show_preroll_frame: bool
-        blocksize: int
-        enable_last_sample: bool
-        last_sample: Gst.Sample | None
-        max_bitrate: int
-        max_lateness: int
-        processing_deadline: int
-        qos: bool
-        render_delay: int
-        stats: Gst.Structure
-        sync: bool
-        throttle_time: int
-        ts_offset: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/GstWebRTC.pyi
+++ b/src/gi-stubs/repository/GstWebRTC.pyi
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -50,15 +51,18 @@ class WebRTCDTLSTransport(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
         certificate: str
         client: bool
-        remote_certificate: str
-        session_id: int
-        state: WebRTCDTLSTransportState
-        transport: WebRTCICETransport
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def remote_certificate(self) -> str: ...
+        @property
+        def session_id(self) -> int: ...
+        @property
+        def state(self) -> WebRTCDTLSTransportState: ...
+        @property
+        def transport(self) -> WebRTCICETransport: ...
 
     @property
     def props(self) -> Props: ...
@@ -122,18 +126,29 @@ class WebRTCDataChannel(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        buffered_amount: int
+        @property
+        def buffered_amount(self) -> int: ...
         buffered_amount_low_threshold: int
-        id: int
-        label: str
-        max_packet_lifetime: int
-        max_retransmits: int
-        negotiated: bool
-        ordered: bool
-        priority: WebRTCPriorityType
-        protocol: str
-        ready_state: WebRTCDataChannelState
+        @property
+        def id(self) -> int: ...
+        @property
+        def label(self) -> str: ...
+        @property
+        def max_packet_lifetime(self) -> int: ...
+        @property
+        def max_retransmits(self) -> int: ...
+        @property
+        def negotiated(self) -> bool: ...
+        @property
+        def ordered(self) -> bool: ...
+        @property
+        def priority(self) -> WebRTCPriorityType: ...
+        @property
+        def protocol(self) -> str: ...
+        @property
+        def ready_state(self) -> WebRTCDataChannelState: ...
 
     @property
     def props(self) -> Props: ...
@@ -189,11 +204,10 @@ class WebRTCICE(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
         max_rtp_port: int
         min_rtp_port: int
-        name: str | None
-        parent: Gst.Object | None
 
     @property
     def props(self) -> Props: ...
@@ -449,10 +463,10 @@ class WebRTCICEStream(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
-        stream_id: int
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def stream_id(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -523,12 +537,14 @@ class WebRTCICETransport(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
-        component: WebRTCICEComponent
-        gathering_state: WebRTCICEGatheringState
-        state: WebRTCICEConnectionState
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def component(self) -> WebRTCICEComponent: ...
+        @property
+        def gathering_state(self) -> WebRTCICEGatheringState: ...
+        @property
+        def state(self) -> WebRTCICEConnectionState: ...
 
     @property
     def props(self) -> Props: ...
@@ -606,10 +622,10 @@ class WebRTCRTPReceiver(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
-        transport: WebRTCDTLSTransport
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def transport(self) -> WebRTCDTLSTransport: ...
 
     @property
     def props(self) -> Props: ...
@@ -645,11 +661,11 @@ class WebRTCRTPSender(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
         priority: WebRTCPriorityType
-        transport: WebRTCDTLSTransport
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def transport(self) -> WebRTCDTLSTransport: ...
 
     @property
     def props(self) -> Props: ...
@@ -704,17 +720,22 @@ class WebRTCRTPTransceiver(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
         codec_preferences: Gst.Caps
-        current_direction: WebRTCRTPTransceiverDirection
+        @property
+        def current_direction(self) -> WebRTCRTPTransceiverDirection: ...
         direction: WebRTCRTPTransceiverDirection
-        kind: WebRTCKind
-        mid: str
-        mlineindex: int
-        receiver: WebRTCRTPReceiver
-        sender: WebRTCRTPSender
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def kind(self) -> WebRTCKind: ...
+        @property
+        def mid(self) -> str: ...
+        @property
+        def mlineindex(self) -> int: ...
+        @property
+        def receiver(self) -> WebRTCRTPReceiver: ...
+        @property
+        def sender(self) -> WebRTCRTPSender: ...
 
     @property
     def props(self) -> Props: ...
@@ -764,13 +785,16 @@ class WebRTCSCTPTransport(Gst.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gst.Object.Props):
-        max_channels: int
-        max_message_size: int
-        state: WebRTCSCTPTransportState
-        transport: WebRTCDTLSTransport
-        name: str | None
-        parent: Gst.Object | None
+        @property
+        def max_channels(self) -> int: ...
+        @property
+        def max_message_size(self) -> int: ...
+        @property
+        def state(self) -> WebRTCSCTPTransportState: ...
+        @property
+        def transport(self) -> WebRTCDTLSTransport: ...
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/Pango.pyi
+++ b/src/gi-stubs/repository/Pango.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -708,12 +709,18 @@ class FontFamily(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        is_monospace: bool
-        is_variable: bool
-        item_type: type[Any]
-        n_items: int
-        name: str
+        @property
+        def is_monospace(self) -> bool: ...
+        @property
+        def is_variable(self) -> bool: ...
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def n_items(self) -> int: ...
+        @property
+        def name(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -773,9 +780,12 @@ class FontMap(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
-        n_items: int
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/Rsvg.pyi
+++ b/src/gi-stubs/repository/Rsvg.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Final
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -75,18 +76,27 @@ class Handle(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         base_uri: str
-        desc: str | None
+        @property
+        def desc(self) -> str | None: ...
         dpi_x: float
         dpi_y: float
-        em: float
-        ex: float
-        flags: HandleFlags
-        height: int
-        metadata: str | None
-        title: str | None
-        width: int
+        @property
+        def em(self) -> float: ...
+        @property
+        def ex(self) -> float: ...
+        @property
+        def flags(self) -> HandleFlags: ...
+        @property
+        def height(self) -> int: ...
+        @property
+        def metadata(self) -> str | None: ...
+        @property
+        def title(self) -> str | None: ...
+        @property
+        def width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...

--- a/src/gi-stubs/repository/_GIRepository3.pyi
+++ b/src/gi-stubs/repository/_GIRepository3.pyi
@@ -152,7 +152,14 @@ class CallableInfo(BaseInfo):
     def may_return_null(self) -> bool: ...
     def skip_return(self) -> bool: ...
 
-class CallbackInfo(CallableInfo): ...
+class CallbackInfo(CallableInfo):
+    """
+    :Constructors:
+
+    ::
+
+        CallbackInfo(**properties)
+    """
 
 class ConstantInfo(BaseInfo):
     """
@@ -192,7 +199,14 @@ class FieldInfo(BaseInfo):
     def get_size(self) -> int: ...
     def get_type_info(self) -> TypeInfo: ...
 
-class FlagsInfo(EnumInfo): ...
+class FlagsInfo(EnumInfo):
+    """
+    :Constructors:
+
+    ::
+
+        FlagsInfo(**properties)
+    """
 
 class FunctionInfo(CallableInfo):
     """
@@ -462,7 +476,14 @@ class UnionInfo(RegisteredTypeInfo):
     def get_size(self) -> int: ...
     def is_discriminated(self) -> bool: ...
 
-class UnresolvedInfo(BaseInfo): ...
+class UnresolvedInfo(BaseInfo):
+    """
+    :Constructors:
+
+    ::
+
+        UnresolvedInfo(**properties)
+    """
 
 class VFuncInfo(CallableInfo):
     """

--- a/src/gi-stubs/repository/_Gdk3.pyi
+++ b/src/gi-stubs/repository/_Gdk3.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 
 from collections.abc import Callable
@@ -2557,8 +2558,10 @@ class AppLaunchContext(Gio.AppLaunchContext):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.AppLaunchContext.Props):
-        display: Display
+        @property
+        def display(self) -> Display: ...
 
     @property
     def props(self) -> Props: ...
@@ -2641,9 +2644,12 @@ class Cursor(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        cursor_type: CursorType
-        display: Display
+        @property
+        def cursor_type(self) -> CursorType: ...
+        @property
+        def display(self) -> Display: ...
 
     @property
     def props(self) -> Props: ...
@@ -2724,22 +2730,36 @@ class Device(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        associated_device: Device | None
-        axes: AxisFlags
-        device_manager: DeviceManager
-        display: Display
-        has_cursor: bool
+        @property
+        def associated_device(self) -> Device | None: ...
+        @property
+        def axes(self) -> AxisFlags: ...
+        @property
+        def device_manager(self) -> DeviceManager: ...
+        @property
+        def display(self) -> Display: ...
+        @property
+        def has_cursor(self) -> bool: ...
         input_mode: InputMode
-        input_source: InputSource
-        n_axes: int
-        name: str
-        num_touches: int
-        product_id: str | None
+        @property
+        def input_source(self) -> InputSource: ...
+        @property
+        def n_axes(self) -> int: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def num_touches(self) -> int: ...
+        @property
+        def product_id(self) -> str | None: ...
         seat: Seat
-        tool: DeviceTool
-        type: DeviceType
-        vendor_id: str | None
+        @property
+        def tool(self) -> DeviceTool: ...
+        @property
+        def type(self) -> DeviceType: ...
+        @property
+        def vendor_id(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -2821,8 +2841,10 @@ class DeviceManager(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: Display | None
+        @property
+        def display(self) -> Display | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -2868,11 +2890,16 @@ class DeviceTool(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        axes: AxisFlags
-        hardware_id: int
-        serial: int
-        tool_type: DeviceToolType
+        @property
+        def axes(self) -> AxisFlags: ...
+        @property
+        def hardware_id(self) -> int: ...
+        @property
+        def serial(self) -> int: ...
+        @property
+        def tool_type(self) -> DeviceToolType: ...
 
     @property
     def props(self) -> Props: ...
@@ -2986,6 +3013,7 @@ class DisplayManager(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         default_display: Display | None
 
@@ -3053,9 +3081,12 @@ class DrawingContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        clip: cairo.Region | None
-        window: Window
+        @property
+        def clip(self) -> cairo.Region | None: ...
+        @property
+        def window(self) -> Window: ...
 
     @property
     def props(self) -> Props: ...
@@ -3475,10 +3506,14 @@ class GLContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: Display | None
-        shared_context: GLContext | None
-        window: Window | None
+        @property
+        def display(self) -> Display | None: ...
+        @property
+        def shared_context(self) -> GLContext | None: ...
+        @property
+        def window(self) -> Window | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -3621,17 +3656,28 @@ class Monitor(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: Display
-        geometry: Rectangle
-        height_mm: int
-        manufacturer: str | None
-        model: str | None
-        refresh_rate: int
-        scale_factor: int
-        subpixel_layout: SubpixelLayout
-        width_mm: int
-        workarea: Rectangle
+        @property
+        def display(self) -> Display: ...
+        @property
+        def geometry(self) -> Rectangle: ...
+        @property
+        def height_mm(self) -> int: ...
+        @property
+        def manufacturer(self) -> str | None: ...
+        @property
+        def model(self) -> str | None: ...
+        @property
+        def refresh_rate(self) -> int: ...
+        @property
+        def scale_factor(self) -> int: ...
+        @property
+        def subpixel_layout(self) -> SubpixelLayout: ...
+        @property
+        def width_mm(self) -> int: ...
+        @property
+        def workarea(self) -> Rectangle: ...
 
     @property
     def props(self) -> Props: ...
@@ -3738,6 +3784,7 @@ class Screen(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         font_options: None | None
         resolution: float
@@ -3811,8 +3858,10 @@ class Seat(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: Display
+        @property
+        def display(self) -> Display: ...
 
     @property
     def props(self) -> Props: ...
@@ -3910,6 +3959,7 @@ class Window(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         cursor: Cursor | None
 

--- a/src/gi-stubs/repository/_Gdk4.pyi
+++ b/src/gi-stubs/repository/_Gdk4.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -2579,8 +2580,10 @@ class AppLaunchContext(Gio.AppLaunchContext):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.AppLaunchContext.Props):
-        display: Display
+        @property
+        def display(self) -> Display: ...
 
     @property
     def props(self) -> Props: ...
@@ -2618,12 +2621,6 @@ class CairoContext(DrawContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(DrawContext.Props):
-        display: Display | None
-        surface: Surface | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, display: Display = ..., surface: Surface = ...) -> None: ...
     def cairo_create(self) -> cairo.Context | None: ...
 
@@ -2647,6 +2644,7 @@ class CicpParams(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         color_primaries: int
         matrix_coefficients: int
@@ -2699,11 +2697,16 @@ class Clipboard(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        content: ContentProvider | None
-        display: Display
-        formats: ContentFormats
-        local: bool
+        @property
+        def content(self) -> ContentProvider | None: ...
+        @property
+        def display(self) -> Display: ...
+        @property
+        def formats(self) -> ContentFormats: ...
+        @property
+        def local(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -2880,9 +2883,12 @@ class ContentProvider(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        formats: ContentFormats
-        storable_formats: ContentFormats
+        @property
+        def formats(self) -> ContentFormats: ...
+        @property
+        def storable_formats(self) -> ContentFormats: ...
 
     @property
     def props(self) -> Props: ...
@@ -3018,12 +3024,18 @@ class Cursor(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        fallback: Cursor | None
-        hotspot_x: int
-        hotspot_y: int
-        name: str | None
-        texture: Texture | None
+        @property
+        def fallback(self) -> Cursor | None: ...
+        @property
+        def hotspot_x(self) -> int: ...
+        @property
+        def hotspot_y(self) -> int: ...
+        @property
+        def name(self) -> str | None: ...
+        @property
+        def texture(self) -> Texture | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -3071,7 +3083,14 @@ class DNDEvent(Event):
     """
     def get_drop(self) -> Drop | None: ...
 
-class DeleteEvent(Event): ...
+class DeleteEvent(Event):
+    """
+    :Constructors:
+
+    ::
+
+        DeleteEvent(**properties)
+    """
 
 class Device(GObject.Object):
     """
@@ -3110,25 +3129,43 @@ class Device(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        active_layout_index: int
-        caps_lock_state: bool
-        direction: Pango.Direction
-        display: Display
-        has_bidi_layouts: bool
-        has_cursor: bool
-        layout_names: list[str] | None
-        modifier_state: ModifierType
-        n_axes: int
-        name: str
-        num_lock_state: bool
-        num_touches: int
-        product_id: str | None
-        scroll_lock_state: bool
+        @property
+        def active_layout_index(self) -> int: ...
+        @property
+        def caps_lock_state(self) -> bool: ...
+        @property
+        def direction(self) -> Pango.Direction: ...
+        @property
+        def display(self) -> Display: ...
+        @property
+        def has_bidi_layouts(self) -> bool: ...
+        @property
+        def has_cursor(self) -> bool: ...
+        @property
+        def layout_names(self) -> list[str] | None: ...
+        @property
+        def modifier_state(self) -> ModifierType: ...
+        @property
+        def n_axes(self) -> int: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def num_lock_state(self) -> bool: ...
+        @property
+        def num_touches(self) -> int: ...
+        @property
+        def product_id(self) -> str | None: ...
+        @property
+        def scroll_lock_state(self) -> bool: ...
         seat: Seat
-        source: InputSource
-        tool: DeviceTool | None
-        vendor_id: str | None
+        @property
+        def source(self) -> InputSource: ...
+        @property
+        def tool(self) -> DeviceTool | None: ...
+        @property
+        def vendor_id(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -3197,11 +3234,16 @@ class DeviceTool(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        axes: AxisFlags
-        hardware_id: int
-        serial: int
-        tool_type: DeviceToolType
+        @property
+        def axes(self) -> AxisFlags: ...
+        @property
+        def hardware_id(self) -> int: ...
+        @property
+        def serial(self) -> int: ...
+        @property
+        def tool_type(self) -> DeviceToolType: ...
 
     @property
     def props(self) -> Props: ...
@@ -3245,12 +3287,18 @@ class Display(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        composited: bool
-        dmabuf_formats: DmabufFormats
-        input_shapes: bool
-        rgba: bool
-        shadow_width: bool
+        @property
+        def composited(self) -> bool: ...
+        @property
+        def dmabuf_formats(self) -> DmabufFormats: ...
+        @property
+        def input_shapes(self) -> bool: ...
+        @property
+        def rgba(self) -> bool: ...
+        @property
+        def shadow_width(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -3309,6 +3357,7 @@ class DisplayManager(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         default_display: Display | None
 
@@ -3356,13 +3405,6 @@ class DmabufTexture(Texture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Texture.Props):
-        color_state: ColorState
-        height: int
-        width: int
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, color_state: ColorState = ..., height: int = ..., width: int = ...
     ) -> None: ...
@@ -3393,6 +3435,7 @@ class DmabufTextureBuilder(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         color_state: ColorState | None
         display: Display
@@ -3483,14 +3526,20 @@ class Drag(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         actions: DragAction
-        content: ContentProvider
-        device: Device
-        display: Display
-        formats: ContentFormats
+        @property
+        def content(self) -> ContentProvider: ...
+        @property
+        def device(self) -> Device: ...
+        @property
+        def display(self) -> Display: ...
+        @property
+        def formats(self) -> ContentFormats: ...
         selected_action: DragAction
-        surface: Surface
+        @property
+        def surface(self) -> Surface: ...
 
     @property
     def props(self) -> Props: ...
@@ -3555,9 +3604,12 @@ class DrawContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: Display | None
-        surface: Surface | None
+        @property
+        def display(self) -> Display | None: ...
+        @property
+        def surface(self) -> Surface | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -3590,13 +3642,20 @@ class Drop(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        actions: DragAction
-        device: Device
-        display: Display
-        drag: Drag | None
-        formats: ContentFormats
-        surface: Surface
+        @property
+        def actions(self) -> DragAction: ...
+        @property
+        def device(self) -> Device: ...
+        @property
+        def display(self) -> Display: ...
+        @property
+        def drag(self) -> Drag | None: ...
+        @property
+        def formats(self) -> ContentFormats: ...
+        @property
+        def surface(self) -> Surface: ...
 
     @property
     def props(self) -> Props: ...
@@ -3762,12 +3821,13 @@ class GLContext(DrawContext):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(DrawContext.Props):
         allowed_apis: GLAPI
-        api: GLAPI
-        shared_context: GLContext | None
-        display: Display | None
-        surface: Surface | None
+        @property
+        def api(self) -> GLAPI: ...
+        @property
+        def shared_context(self) -> GLContext | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -3830,13 +3890,6 @@ class GLTexture(Texture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Texture.Props):
-        color_state: ColorState
-        height: int
-        width: int
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, color_state: ColorState = ..., height: int = ..., width: int = ...
     ) -> None: ...
@@ -3878,6 +3931,7 @@ class GLTextureBuilder(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         color_state: ColorState
         context: GLContext | None
@@ -4001,13 +4055,6 @@ class MemoryTexture(Texture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Texture.Props):
-        color_state: ColorState
-        height: int
-        width: int
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, color_state: ColorState = ..., height: int = ..., width: int = ...
     ) -> None: ...
@@ -4045,6 +4092,7 @@ class MemoryTextureBuilder(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         bytes: GLib.Bytes | None
         color_state: ColorState
@@ -4127,20 +4175,34 @@ class Monitor(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        connector: str | None
-        description: str | None
-        display: Display
-        geometry: Rectangle
-        height_mm: int
-        manufacturer: str | None
-        model: str | None
-        refresh_rate: int
-        scale: float
-        scale_factor: int
-        subpixel_layout: SubpixelLayout
-        valid: bool
-        width_mm: int
+        @property
+        def connector(self) -> str | None: ...
+        @property
+        def description(self) -> str | None: ...
+        @property
+        def display(self) -> Display: ...
+        @property
+        def geometry(self) -> Rectangle: ...
+        @property
+        def height_mm(self) -> int: ...
+        @property
+        def manufacturer(self) -> str | None: ...
+        @property
+        def model(self) -> str | None: ...
+        @property
+        def refresh_rate(self) -> int: ...
+        @property
+        def scale(self) -> float: ...
+        @property
+        def scale_factor(self) -> int: ...
+        @property
+        def subpixel_layout(self) -> SubpixelLayout: ...
+        @property
+        def valid(self) -> bool: ...
+        @property
+        def width_mm(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -4160,7 +4222,15 @@ class Monitor(GObject.Object):
     def is_valid(self) -> bool: ...
 
 class MonitorClass(_gi.Struct): ...
-class MotionEvent(Event): ...
+
+class MotionEvent(Event):
+    """
+    :Constructors:
+
+    ::
+
+        MotionEvent(**properties)
+    """
 
 class PadEvent(Event):
     """
@@ -4277,7 +4347,14 @@ class PopupLayout(GObject.GBoxed):
     def set_surface_anchor(self, anchor: Gravity) -> None: ...
     def unref(self) -> None: ...
 
-class ProximityEvent(Event): ...
+class ProximityEvent(Event):
+    """
+    :Constructors:
+
+    ::
+
+        ProximityEvent(**properties)
+    """
 
 class RGBA(GObject.GBoxed):
     """
@@ -4366,8 +4443,10 @@ class Seat(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        display: Display
+        @property
+        def display(self) -> Display: ...
 
     @property
     def props(self) -> Props: ...
@@ -4381,7 +4460,20 @@ class Seat(GObject.Object):
     def get_pointer(self) -> Device | None: ...
     def get_tools(self) -> list[DeviceTool]: ...
 
-class Snapshot(GObject.Object): ...
+class Snapshot(GObject.Object):
+    """
+    :Constructors:
+
+    ::
+
+        Snapshot(**properties)
+
+    Object GdkSnapshot
+
+    Signals from GObject:
+      notify (GParam)
+    """
+
 class SnapshotClass(_gi.Struct): ...
 
 class Surface(GObject.Object):
@@ -4416,15 +4508,23 @@ class Surface(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         cursor: Cursor | None
-        display: Display
-        frame_clock: FrameClock
-        height: int
-        mapped: bool
-        scale: float
-        scale_factor: int
-        width: int
+        @property
+        def display(self) -> Display: ...
+        @property
+        def frame_clock(self) -> FrameClock: ...
+        @property
+        def height(self) -> int: ...
+        @property
+        def mapped(self) -> bool: ...
+        @property
+        def scale(self) -> float: ...
+        @property
+        def scale_factor(self) -> int: ...
+        @property
+        def width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -4498,10 +4598,14 @@ class Texture(GObject.Object, Paintable, Gio.Icon, Gio.LoadableIcon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        color_state: ColorState
-        height: int
-        width: int
+        @property
+        def color_state(self) -> ColorState: ...
+        @property
+        def height(self) -> int: ...
+        @property
+        def width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -4687,12 +4791,6 @@ class VulkanContext(DrawContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(DrawContext.Props):
-        display: Display | None
-        surface: Surface | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, display: Display = ..., surface: Surface = ...) -> None: ...
 
 class AnchorHints(GObject.GFlags):

--- a/src/gi-stubs/repository/_Gtk3.pyi
+++ b/src/gi-stubs/repository/_Gtk3.pyi
@@ -2,6 +2,7 @@ from typing import Any
 from typing import Final
 from typing import overload
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -11,6 +12,7 @@ from collections.abc import Sequence
 
 import cairo
 from gi import _gi
+from gi import _gtktemplate
 from gi.repository import _Gdk3
 from gi.repository import Atk
 from gi.repository import GdkPixbuf
@@ -1252,98 +1254,23 @@ class AboutDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         artists: list[str]
         authors: list[str]
-        comments: str
-        copyright: str
+        comments: str | None
+        copyright: str | None
         documenters: list[str]
-        license: str
+        license: str | None
         license_type: License
-        logo: GdkPixbuf.Pixbuf
-        logo_icon_name: str
+        logo: GdkPixbuf.Pixbuf | None
+        logo_icon_name: str | None
         program_name: str
-        translator_credits: str
-        version: str
-        website: str
+        translator_credits: str | None
+        version: str | None
+        website: str | None
         website_label: str
         wrap_license: bool
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -1513,9 +1440,12 @@ class AccelGroup(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        is_locked: bool
-        modifier_mask: _Gdk3.ModifierType
+        @property
+        def is_locked(self) -> bool: ...
+        @property
+        def modifier_mask(self) -> _Gdk3.ModifierType: ...
 
     @property
     def props(self) -> Props: ...
@@ -1838,72 +1768,10 @@ class AccelLabel(Label):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Label.Props):
         accel_closure: Callable[..., Any] | None
         accel_widget: Widget | None
-        angle: float
-        attributes: Pango.AttrList | None
-        cursor_position: int
-        ellipsize: Pango.EllipsizeMode
-        justify: Justification
-        label: str
-        lines: int
-        max_width_chars: int
-        mnemonic_keyval: int
-        mnemonic_widget: Widget | None
-        selectable: bool
-        selection_bound: int
-        single_line_mode: bool
-        track_visited_links: bool
-        use_markup: bool
-        use_underline: bool
-        width_chars: int
-        wrap: bool
-        wrap_mode: Pango.WrapMode
-        xalign: float
-        yalign: float
-        xpad: int
-        ypad: int
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        pattern: str
 
     @property
     def props(self) -> Props: ...
@@ -2134,25 +2002,9 @@ class Accessible(Atk.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Atk.Object.Props):
         widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
 
     @property
     def props(self) -> Props: ...
@@ -2256,6 +2108,7 @@ class Action(GObject.Object, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         action_group: ActionGroup
         always_show_image: bool
@@ -2264,7 +2117,8 @@ class Action(GObject.Object, Buildable):
         icon_name: str
         is_important: bool
         label: str
-        name: str
+        @property
+        def name(self) -> str: ...
         sensitive: bool
         short_label: str
         stock_id: str
@@ -2535,52 +2389,6 @@ class ActionBar(Bin):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Bin.Props):
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def bin(self) -> Bin: ...
     def __init__(
@@ -2719,9 +2527,11 @@ class ActionGroup(GObject.Object, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        accel_group: AccelGroup
-        name: str
+        accel_group: AccelGroup | None
+        @property
+        def name(self) -> str: ...
         sensitive: bool
         visible: bool
 
@@ -2957,6 +2767,7 @@ class Adjustment(GObject.InitiallyUnowned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         lower: float
         page_increment: float
@@ -3233,6 +3044,7 @@ class Alignment(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         bottom_padding: int
         left_padding: int
@@ -3242,48 +3054,6 @@ class Alignment(Bin):
         xscale: float
         yalign: float
         yscale: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -3621,70 +3391,14 @@ class AppChooserButton(ComboBox, AppChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ComboBox.Props):
         heading: str | None
         show_default_item: bool
         show_dialog_item: bool
-        active: int
-        active_id: str | None
-        add_tearoffs: bool
-        button_sensitivity: SensitivityType
-        cell_area: CellArea
-        column_span_column: int
-        entry_text_column: int
-        has_entry: bool
-        has_frame: bool
-        id_column: int
-        model: TreeModel
-        popup_fixed_width: bool
-        popup_shown: bool
-        row_span_column: int
-        tearoff_title: str
-        wrap_width: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        content_type: str
+        @property
+        def content_type(self) -> str: ...
         editing_canceled: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -3698,6 +3412,8 @@ class AppChooserButton(ComboBox, AppChooser):
         heading: str = ...,
         show_default_item: bool = ...,
         show_dialog_item: bool = ...,
+        content_type: str = ...,
+        editing_canceled: bool = ...,
         active: int = ...,
         active_id: str | None = ...,
         add_tearoffs: bool = ...,
@@ -3752,8 +3468,6 @@ class AppChooserButton(ComboBox, AppChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        content_type: str = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def append_custom_item(self, name: str, label: str, icon: Gio.Icon) -> None: ...
     def append_separator(self) -> None: ...
@@ -4054,86 +3768,13 @@ class AppChooserDialog(Dialog, AppChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        gfile: Gio.File
+        @property
+        def gfile(self) -> Gio.File: ...
         heading: str | None
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        content_type: str
-        startup_id: str
-        child: Widget
+        @property
+        def content_type(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -4146,6 +3787,7 @@ class AppChooserDialog(Dialog, AppChooser):
         *,
         gfile: Gio.File = ...,
         heading: str = ...,
+        content_type: str = ...,
         use_header_bar: int = ...,
         accept_focus: bool = ...,
         application: Application | None = ...,
@@ -4215,7 +3857,6 @@ class AppChooserDialog(Dialog, AppChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        content_type: str = ...,
     ) -> None: ...
     def get_heading(self) -> str | None: ...
     def get_widget(self) -> Widget: ...
@@ -4450,6 +4091,7 @@ class AppChooserWidget(Box, AppChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         default_text: str
         show_all: bool
@@ -4457,53 +4099,9 @@ class AppChooserWidget(Box, AppChooser):
         show_fallback: bool
         show_other: bool
         show_recommended: bool
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        content_type: str
+        @property
+        def content_type(self) -> str: ...
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -4520,6 +4118,8 @@ class AppChooserWidget(Box, AppChooser):
         show_fallback: bool = ...,
         show_other: bool = ...,
         show_recommended: bool = ...,
+        content_type: str = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -4562,8 +4162,6 @@ class AppChooserWidget(Box, AppChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        content_type: str = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_application_activated(self, app_info: Gio.AppInfo) -> None: ...
     def do_application_selected(self, app_info: Gio.AppInfo) -> None: ...
@@ -4673,21 +4271,15 @@ class Application(Gio.Application):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.Application.Props):
-        active_window: Window | None
+        @property
+        def active_window(self) -> Window | None: ...
         app_menu: Gio.MenuModel | None
-        menubar: Gio.MenuModel
+        menubar: Gio.MenuModel | None
         register_session: bool
-        screensaver_active: bool
-        application_id: str | None
-        flags: Gio.ApplicationFlags
-        inactivity_timeout: int
-        is_busy: bool
-        is_registered: bool
-        is_remote: bool
-        resource_base_path: str | None
-        version: str | None
-        action_group: Gio.ActionGroup | None
+        @property
+        def screensaver_active(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -5029,83 +4621,9 @@ class ApplicationWindow(Window, Gio.ActionGroup, Gio.ActionMap):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         show_menubar: bool
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -5390,52 +4908,10 @@ class Arrow(Misc):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Misc.Props):
         arrow_type: ArrowType
         shadow_type: ShadowType
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -5563,28 +5039,6 @@ class ArrowAccessible(WidgetAccessible, Atk.Image):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -5836,58 +5290,12 @@ class AspectFrame(Frame):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Frame.Props):
         obey_child: bool
         ratio: float
         xalign: float
         yalign: float
-        label: str | None
-        label_widget: Widget | None
-        label_xalign: float
-        label_yalign: float
-        shadow_type: ShadowType
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -6238,83 +5646,10 @@ class Assistant(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
+        @property
+        def use_header_bar(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -6634,52 +5969,6 @@ class Bin(Container):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Container.Props):
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def container(self) -> Container: ...
     @property
@@ -6909,29 +6198,6 @@ class BooleanCellAccessible(RendererCellAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RendererCellAccessible.Props):
-        renderer: CellRenderer
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RendererCellAccessible: ...
     @property
@@ -7178,53 +6444,12 @@ class Box(Container, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         baseline_position: BaselinePosition
         homogeneous: bool
         spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -7238,6 +6463,7 @@ class Box(Container, Orientable):
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
+        orientation: Orientation = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -7277,7 +6503,6 @@ class Box(Container, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_baseline_position(self) -> BaselinePosition: ...
     def get_center_widget(self) -> Widget | None: ...
@@ -7415,8 +6640,9 @@ class Builder(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        translation_domain: str
+        translation_domain: str | None
 
     @property
     def props(self) -> Props: ...
@@ -7698,6 +6924,7 @@ class Button(Bin, Actionable, Activatable, Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         always_show_image: bool
         image: Widget | None
@@ -7708,52 +6935,10 @@ class Button(Bin, Actionable, Activatable, Container):
         use_underline: bool
         xalign: float
         yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -7773,6 +6958,10 @@ class Button(Bin, Actionable, Activatable, Container):
         use_underline: bool = ...,
         xalign: float = ...,
         yalign: float = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -7812,10 +7001,6 @@ class Button(Bin, Actionable, Activatable, Container):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def clicked(self) -> None: ...
     def do_activate(self) -> None: ...
@@ -7935,28 +7120,6 @@ class ButtonAccessible(ContainerAccessible, Atk.Action, Atk.Image):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -8185,54 +7348,10 @@ class ButtonBox(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         layout_style: ButtonBoxStyle
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -8244,6 +7363,7 @@ class ButtonBox(Box):
         self,
         *,
         layout_style: ButtonBoxStyle = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -8286,7 +7406,6 @@ class ButtonBox(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_child_non_homogeneous(self, child: Widget) -> bool: ...
     def get_child_secondary(self, child: Widget) -> bool: ...
@@ -8533,6 +7652,7 @@ class Calendar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         day: int
         detail_height_rows: int
@@ -8544,45 +7664,6 @@ class Calendar(Widget):
         show_heading: bool
         show_week_numbers: bool
         year: int
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -8758,28 +7839,6 @@ class CellAccessible(Accessible, Atk.Action, Atk.Component, Atk.TableCell):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Accessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Accessible: ...
     @property
@@ -8923,9 +7982,12 @@ class CellArea(GObject.InitiallyUnowned, Buildable, CellLayout):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
-        edit_widget: CellEditable
-        edited_cell: CellRenderer
+        @property
+        def edit_widget(self) -> CellEditable: ...
+        @property
+        def edited_cell(self) -> CellRenderer: ...
         focus_cell: CellRenderer
 
     @property
@@ -9175,11 +8237,9 @@ class CellAreaBox(CellArea, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellArea.Props):
         spacing: int
-        edit_widget: CellEditable
-        edited_cell: CellRenderer
-        focus_cell: CellRenderer
         orientation: Orientation
 
     @property
@@ -9192,8 +8252,8 @@ class CellAreaBox(CellArea, Orientable):
         self,
         *,
         spacing: int = ...,
-        focus_cell: CellRenderer = ...,
         orientation: Orientation = ...,
+        focus_cell: CellRenderer = ...,
     ) -> None: ...
     def get_spacing(self) -> int: ...
     @classmethod
@@ -9345,12 +8405,18 @@ class CellAreaContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        area: CellArea
-        minimum_height: int
-        minimum_width: int
-        natural_height: int
-        natural_width: int
+        @property
+        def area(self) -> CellArea: ...
+        @property
+        def minimum_height(self) -> int: ...
+        @property
+        def minimum_width(self) -> int: ...
+        @property
+        def natural_height(self) -> int: ...
+        @property
+        def natural_width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -9534,11 +8600,14 @@ class CellRenderer(GObject.InitiallyUnowned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
+        cell_background: str
         cell_background_gdk: _Gdk3.Color
         cell_background_rgba: _Gdk3.RGBA
         cell_background_set: bool
-        editing: bool
+        @property
+        def editing(self) -> bool: ...
         height: int
         is_expanded: bool
         is_expander: bool
@@ -9550,7 +8619,6 @@ class CellRenderer(GObject.InitiallyUnowned):
         xpad: int
         yalign: float
         ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -9846,75 +8914,12 @@ class CellRendererAccel(CellRendererText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRendererText.Props):
         accel_key: int
         accel_mode: CellRendererAccelMode
         accel_mods: _Gdk3.ModifierType
         keycode: int
-        align_set: bool
-        alignment: Pango.Alignment
-        attributes: Pango.AttrList
-        background_gdk: _Gdk3.Color
-        background_rgba: _Gdk3.RGBA
-        background_set: bool
-        editable: bool
-        editable_set: bool
-        ellipsize: Pango.EllipsizeMode
-        ellipsize_set: bool
-        family: str
-        family_set: bool
-        font: str
-        font_desc: Pango.FontDescription
-        foreground_gdk: _Gdk3.Color
-        foreground_rgba: _Gdk3.RGBA
-        foreground_set: bool
-        language: str
-        language_set: bool
-        max_width_chars: int
-        placeholder_text: str
-        rise: int
-        rise_set: bool
-        scale: float
-        scale_set: bool
-        single_paragraph_mode: bool
-        size: int
-        size_points: float
-        size_set: bool
-        stretch: Pango.Stretch
-        stretch_set: bool
-        strikethrough: bool
-        strikethrough_set: bool
-        style: Pango.Style
-        style_set: bool
-        text: str
-        underline: Pango.Underline
-        underline_set: bool
-        variant: Pango.Variant
-        variant_set: bool
-        weight: int
-        weight_set: bool
-        width_chars: int
-        wrap_mode: Pango.WrapMode
-        wrap_width: int
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -10281,74 +9286,11 @@ class CellRendererCombo(CellRendererText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRendererText.Props):
         has_entry: bool
         model: TreeModel
         text_column: int
-        align_set: bool
-        alignment: Pango.Alignment
-        attributes: Pango.AttrList
-        background_gdk: _Gdk3.Color
-        background_rgba: _Gdk3.RGBA
-        background_set: bool
-        editable: bool
-        editable_set: bool
-        ellipsize: Pango.EllipsizeMode
-        ellipsize_set: bool
-        family: str
-        family_set: bool
-        font: str
-        font_desc: Pango.FontDescription
-        foreground_gdk: _Gdk3.Color
-        foreground_rgba: _Gdk3.RGBA
-        foreground_set: bool
-        language: str
-        language_set: bool
-        max_width_chars: int
-        placeholder_text: str
-        rise: int
-        rise_set: bool
-        scale: float
-        scale_set: bool
-        single_paragraph_mode: bool
-        size: int
-        size_points: float
-        size_set: bool
-        stretch: Pango.Stretch
-        stretch_set: bool
-        strikethrough: bool
-        strikethrough_set: bool
-        style: Pango.Style
-        style_set: bool
-        text: str
-        underline: Pango.Underline
-        underline_set: bool
-        variant: Pango.Variant
-        variant_set: bool
-        weight: int
-        weight_set: bool
-        width_chars: int
-        wrap_mode: Pango.WrapMode
-        wrap_width: int
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -10516,6 +9458,7 @@ class CellRendererPixbuf(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         follow_state: bool
         gicon: Gio.Icon
@@ -10527,22 +9470,6 @@ class CellRendererPixbuf(CellRenderer):
         stock_id: str
         stock_size: int
         surface: cairo.Surface
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -10662,6 +9589,7 @@ class CellRendererProgress(CellRenderer, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         inverted: bool
         pulse: int
@@ -10669,23 +9597,7 @@ class CellRendererProgress(CellRenderer, Orientable):
         text_xalign: float
         text_yalign: float
         value: int
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
         orientation: Orientation
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -10702,6 +9614,7 @@ class CellRendererProgress(CellRenderer, Orientable):
         text_xalign: float = ...,
         text_yalign: float = ...,
         value: int = ...,
+        orientation: Orientation = ...,
         cell_background: str = ...,
         cell_background_gdk: _Gdk3.Color = ...,
         cell_background_rgba: _Gdk3.RGBA = ...,
@@ -10717,7 +9630,6 @@ class CellRendererProgress(CellRenderer, Orientable):
         xpad: int = ...,
         yalign: float = ...,
         ypad: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> CellRendererProgress: ...
@@ -10896,74 +9808,11 @@ class CellRendererSpin(CellRendererText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRendererText.Props):
         adjustment: Adjustment
         climb_rate: float
         digits: int
-        align_set: bool
-        alignment: Pango.Alignment
-        attributes: Pango.AttrList
-        background_gdk: _Gdk3.Color
-        background_rgba: _Gdk3.RGBA
-        background_set: bool
-        editable: bool
-        editable_set: bool
-        ellipsize: Pango.EllipsizeMode
-        ellipsize_set: bool
-        family: str
-        family_set: bool
-        font: str
-        font_desc: Pango.FontDescription
-        foreground_gdk: _Gdk3.Color
-        foreground_rgba: _Gdk3.RGBA
-        foreground_set: bool
-        language: str
-        language_set: bool
-        max_width_chars: int
-        placeholder_text: str
-        rise: int
-        rise_set: bool
-        scale: float
-        scale_set: bool
-        single_paragraph_mode: bool
-        size: int
-        size_points: float
-        size_set: bool
-        stretch: Pango.Stretch
-        stretch_set: bool
-        strikethrough: bool
-        strikethrough_set: bool
-        style: Pango.Style
-        style_set: bool
-        text: str
-        underline: Pango.Underline
-        underline_set: bool
-        variant: Pango.Variant
-        variant_set: bool
-        weight: int
-        weight_set: bool
-        width_chars: int
-        wrap_mode: Pango.WrapMode
-        wrap_width: int
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -11117,26 +9966,11 @@ class CellRendererSpinner(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         active: bool
         pulse: int
         size: IconSize
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -11335,10 +10169,12 @@ class CellRendererText(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         align_set: bool
         alignment: Pango.Alignment
         attributes: Pango.AttrList
+        background: str
         background_gdk: _Gdk3.Color
         background_rgba: _Gdk3.RGBA
         background_set: bool
@@ -11350,11 +10186,13 @@ class CellRendererText(CellRenderer):
         family_set: bool
         font: str
         font_desc: Pango.FontDescription
+        foreground: str
         foreground_gdk: _Gdk3.Color
         foreground_rgba: _Gdk3.RGBA
         foreground_set: bool
         language: str
         language_set: bool
+        markup: str
         max_width_chars: int
         placeholder_text: str
         rise: int
@@ -11381,25 +10219,6 @@ class CellRendererText(CellRenderer):
         width_chars: int
         wrap_mode: Pango.WrapMode
         wrap_width: int
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -11561,28 +10380,13 @@ class CellRendererToggle(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         activatable: bool
         active: bool
         inconsistent: bool
         indicator_size: int
         radio: bool
-        cell_background_gdk: _Gdk3.Color
-        cell_background_rgba: _Gdk3.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -11828,56 +10632,20 @@ class CellView(Widget, CellLayout, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
+        background: str
         background_gdk: _Gdk3.Color
         background_rgba: _Gdk3.RGBA
         background_set: bool
-        cell_area: CellArea
-        cell_area_context: CellAreaContext
+        @property
+        def cell_area(self) -> CellArea: ...
+        @property
+        def cell_area_context(self) -> CellAreaContext: ...
         draw_sensitive: bool
         fit_model: bool
         model: TreeModel | None
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        background: str
 
     @property
     def props(self) -> Props: ...
@@ -11897,6 +10665,7 @@ class CellView(Widget, CellLayout, Orientable):
         draw_sensitive: bool = ...,
         fit_model: bool = ...,
         model: TreeModel | None = ...,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -11933,7 +10702,6 @@ class CellView(Widget, CellLayout, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_displayed_row(self) -> TreePath | None: ...
     def get_draw_sensitive(self) -> bool: ...
@@ -12190,65 +10958,12 @@ class CheckButton(ToggleButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToggleButton.Props):
-        active: bool
-        draw_indicator: bool
-        inconsistent: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -12257,6 +10972,10 @@ class CheckButton(ToggleButton):
     def __init__(
         self,
         *,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         active: bool = ...,
         draw_indicator: bool = ...,
         inconsistent: bool = ...,
@@ -12308,10 +11027,6 @@ class CheckButton(ToggleButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_draw_indicator(self, cr: cairo.Context[_SomeSurface]) -> None: ...
     @classmethod
@@ -12548,61 +11263,15 @@ class CheckMenuItem(MenuItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MenuItem.Props):
         active: bool
         draw_as_radio: bool
         inconsistent: bool
-        accel_path: str | None
-        label: str
-        right_justified: bool
-        submenu: Menu | None
-        use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -12616,6 +11285,10 @@ class CheckMenuItem(MenuItem):
         active: bool = ...,
         draw_as_radio: bool = ...,
         inconsistent: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         accel_path: str | None = ...,
         label: str = ...,
         right_justified: bool = ...,
@@ -12660,10 +11333,6 @@ class CheckMenuItem(MenuItem):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_draw_indicator(self, cr: cairo.Context[_SomeSurface]) -> None: ...
     def do_toggled(self) -> None: ...
@@ -12763,28 +11432,6 @@ class CheckMenuItemAccessible(MenuItemAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(MenuItemAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> MenuItemAccessible: ...
     @property
@@ -13126,6 +11773,7 @@ class ColorButton(Button, ColorChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         alpha: int
         color: _Gdk3.Color
@@ -13133,61 +11781,10 @@ class ColorButton(Button, ColorChooser):
         show_editor: bool
         title: str
         use_alpha: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -13204,6 +11801,10 @@ class ColorButton(Button, ColorChooser):
         show_editor: bool = ...,
         title: str = ...,
         use_alpha: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -13252,10 +11853,6 @@ class ColorButton(Button, ColorChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_color_set(self) -> None: ...
     def get_alpha(self) -> int: ...
@@ -13575,86 +12172,11 @@ class ColorChooserDialog(Dialog, ColorChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         show_editor: bool
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         rgba: _Gdk3.RGBA
         use_alpha: bool
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -13666,6 +12188,8 @@ class ColorChooserDialog(Dialog, ColorChooser):
         self,
         *,
         show_editor: bool = ...,
+        rgba: _Gdk3.RGBA = ...,
+        use_alpha: bool = ...,
         use_header_bar: int = ...,
         accept_focus: bool = ...,
         application: Application | None = ...,
@@ -13735,8 +12259,6 @@ class ColorChooserDialog(Dialog, ColorChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        rgba: _Gdk3.RGBA = ...,
-        use_alpha: bool = ...,
     ) -> None: ...
     @classmethod
     def new(
@@ -13975,56 +12497,12 @@ class ColorChooserWidget(Box, ColorChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         show_editor: bool
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         rgba: _Gdk3.RGBA
         use_alpha: bool
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -14036,6 +12514,9 @@ class ColorChooserWidget(Box, ColorChooser):
         self,
         *,
         show_editor: bool = ...,
+        rgba: _Gdk3.RGBA = ...,
+        use_alpha: bool = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -14078,9 +12559,6 @@ class ColorChooserWidget(Box, ColorChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        rgba: _Gdk3.RGBA = ...,
-        use_alpha: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> ColorChooserWidget: ...
@@ -14300,58 +12778,14 @@ class ColorSelection(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         current_alpha: int
         current_color: _Gdk3.Color
         current_rgba: _Gdk3.RGBA
         has_opacity_control: bool
         has_palette: bool
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -14367,6 +12801,7 @@ class ColorSelection(Box):
         current_rgba: _Gdk3.RGBA = ...,
         has_opacity_control: bool = ...,
         has_palette: bool = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -14409,7 +12844,6 @@ class ColorSelection(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_color_changed(self) -> None: ...
     def get_current_alpha(self) -> int: ...
@@ -14721,87 +13155,16 @@ class ColorSelectionDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        cancel_button: Widget
-        color_selection: Widget
-        help_button: Widget
-        ok_button: Widget
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
+        @property
+        def cancel_button(self) -> Widget: ...
+        @property
+        def color_selection(self) -> Widget: ...
+        @property
+        def help_button(self) -> Widget: ...
+        @property
+        def ok_button(self) -> Widget: ...
 
     @property
     def props(self) -> Props: ...
@@ -15129,66 +13492,28 @@ class ComboBox(Bin, CellEditable, CellLayout, Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         active: int
         active_id: str | None
         add_tearoffs: bool
         button_sensitivity: SensitivityType
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         column_span_column: int
         entry_text_column: int
-        has_entry: bool
+        @property
+        def has_entry(self) -> bool: ...
         has_frame: bool
         id_column: int
-        model: TreeModel
+        model: TreeModel | None
         popup_fixed_width: bool
-        popup_shown: bool
+        @property
+        def popup_shown(self) -> bool: ...
         row_span_column: int
         tearoff_title: str
         wrap_width: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         editing_canceled: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -15214,6 +13539,7 @@ class ComboBox(Bin, CellEditable, CellLayout, Container):
         row_span_column: int = ...,
         tearoff_title: str = ...,
         wrap_width: int = ...,
+        editing_canceled: bool = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -15253,7 +13579,6 @@ class ComboBox(Bin, CellEditable, CellLayout, Container):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def do_changed(self) -> None: ...
     def do_format_entry_text(self, path: str) -> str: ...
@@ -15380,28 +13705,6 @@ class ComboBoxAccessible(ContainerAccessible, Atk.Action, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -15685,66 +13988,9 @@ class ComboBoxText(ComboBox):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ComboBox.Props):
-        active: int
-        active_id: str | None
-        add_tearoffs: bool
-        button_sensitivity: SensitivityType
-        cell_area: CellArea
-        column_span_column: int
-        entry_text_column: int
-        has_entry: bool
-        has_frame: bool
-        id_column: int
-        model: TreeModel
-        popup_fixed_width: bool
-        popup_shown: bool
-        row_span_column: int
-        tearoff_title: str
-        wrap_width: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         editing_canceled: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -15755,6 +14001,7 @@ class ComboBoxText(ComboBox):
     def __init__(
         self,
         *,
+        editing_canceled: bool = ...,
         active: int = ...,
         active_id: str | None = ...,
         add_tearoffs: bool = ...,
@@ -15809,7 +14056,6 @@ class ComboBoxText(ComboBox):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def append(self, id: str | None, text: str) -> None: ...
     def append_text(self, text: str) -> None: ...
@@ -15839,7 +14085,7 @@ class ComboBoxTextClass(_gi.Struct):
 
 class ComboBoxTextPrivate(_gi.Struct): ...
 
-class Container(Widget, Widget):
+class Container(Widget):
     """
     :Constructors:
 
@@ -16017,49 +14263,11 @@ class Container(Widget, Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         child: Widget
+        resize_mode: ResizeMode
 
     @property
     def props(self) -> Props: ...
@@ -16255,28 +14463,6 @@ class ContainerAccessible(WidgetAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -16389,28 +14575,6 @@ class ContainerCellAccessible(CellAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(CellAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> CellAccessible: ...
     @property
@@ -16825,83 +14989,10 @@ class Dialog(Window, Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
+        @property
+        def use_header_bar(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -17200,49 +15291,6 @@ class DrawingArea(Widget):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Widget.Props):
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def widget(self) -> Widget: ...
     @property
@@ -17650,13 +15698,15 @@ class Entry(Widget, CellEditable, Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activates_default: bool
         attributes: Pango.AttrList | None
         buffer: EntryBuffer
         caps_lock_warning: bool
-        completion: EntryCompletion
-        cursor_position: int
+        completion: EntryCompletion | None
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_emoji_completion: bool
         has_frame: bool
@@ -17669,7 +15719,7 @@ class Entry(Widget, CellEditable, Editable):
         max_length: int
         max_width_chars: int
         overwrite_mode: bool
-        placeholder_text: str
+        placeholder_text: str | None
         populate_all: bool
         primary_icon_activatable: bool
         primary_icon_gicon: Gio.Icon
@@ -17677,70 +15727,36 @@ class Entry(Widget, CellEditable, Editable):
         primary_icon_pixbuf: GdkPixbuf.Pixbuf
         primary_icon_sensitive: bool
         primary_icon_stock: str
-        primary_icon_storage_type: ImageType
+        @property
+        def primary_icon_storage_type(self) -> ImageType: ...
         primary_icon_tooltip_markup: str
         primary_icon_tooltip_text: str
         progress_fraction: float
         progress_pulse_step: float
-        scroll_offset: int
+        @property
+        def scroll_offset(self) -> int: ...
         secondary_icon_activatable: bool
         secondary_icon_gicon: Gio.Icon
         secondary_icon_name: str
         secondary_icon_pixbuf: GdkPixbuf.Pixbuf
         secondary_icon_sensitive: bool
         secondary_icon_stock: str
-        secondary_icon_storage_type: ImageType
+        @property
+        def secondary_icon_storage_type(self) -> ImageType: ...
         secondary_icon_tooltip_markup: str
         secondary_icon_tooltip_text: str
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         shadow_type: ShadowType
         show_emoji_icon: bool
         tabs: Pango.TabArray | None
         text: str
-        text_length: int
+        @property
+        def text_length(self) -> int: ...
         truncate_multiline: bool
         visibility: bool
         width_chars: int
         xalign: float
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         editing_canceled: bool
 
     @property
@@ -17797,6 +15813,7 @@ class Entry(Widget, CellEditable, Editable):
         visibility: bool = ...,
         width_chars: int = ...,
         xalign: float = ...,
+        editing_canceled: bool = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -17833,7 +15850,6 @@ class Entry(Widget, CellEditable, Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def do_activate(self) -> None: ...
     def do_backspace(self) -> None: ...
@@ -18033,28 +16049,6 @@ class EntryAccessible(WidgetAccessible, Atk.Action, Atk.EditableText, Atk.Text):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -18118,8 +16112,10 @@ class EntryBuffer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        length: int
+        @property
+        def length(self) -> int: ...
         max_length: int
         text: str
 
@@ -18255,8 +16251,10 @@ class EntryCompletion(GObject.Object, Buildable, CellLayout):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         inline_completion: bool
         inline_selection: bool
         minimum_key_length: int
@@ -18410,27 +16408,6 @@ class EntryIconAccessible(Atk.Object, Atk.Action, Atk.Component):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Atk.Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -18637,51 +16614,10 @@ class EventBox(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         above_child: bool
         visible_window: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -18773,9 +16709,11 @@ class EventController(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         propagation_phase: PropagationPhase
-        widget: Widget
+        @property
+        def widget(self) -> Widget: ...
 
     @property
     def props(self) -> Props: ...
@@ -18818,12 +16756,6 @@ class EventControllerKey(EventController):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EventController.Props):
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, propagation_phase: PropagationPhase = ..., widget: Widget = ...
     ) -> None: ...
@@ -18861,12 +16793,6 @@ class EventControllerMotion(EventController):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EventController.Props):
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, propagation_phase: PropagationPhase = ..., widget: Widget = ...
     ) -> None: ...
@@ -18905,10 +16831,9 @@ class EventControllerScroll(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
         flags: EventControllerScrollFlags
-        propagation_phase: PropagationPhase
-        widget: Widget
 
     @property
     def props(self) -> Props: ...
@@ -19129,6 +17054,7 @@ class Expander(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         expanded: bool
         label: str | None
@@ -19138,48 +17064,6 @@ class Expander(Bin):
         spacing: int
         use_markup: bool
         use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -19333,28 +17217,6 @@ class ExpanderAccessible(ContainerAccessible, Atk.Action):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -19692,53 +17554,10 @@ class FileChooserButton(Box, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         title: str
         width_chars: int
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action: FileChooserAction
         create_folders: bool
         do_overwrite_confirmation: bool
@@ -19751,8 +17570,6 @@ class FileChooserButton(Box, FileChooser):
         show_hidden: bool
         use_preview_label: bool
         orientation: Orientation
-        dialog: FileChooser
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -19766,6 +17583,18 @@ class FileChooserButton(Box, FileChooser):
         dialog: FileChooser = ...,
         title: str = ...,
         width_chars: int = ...,
+        action: FileChooserAction = ...,
+        create_folders: bool = ...,
+        do_overwrite_confirmation: bool = ...,
+        extra_widget: Widget = ...,
+        filter: FileFilter = ...,
+        local_only: bool = ...,
+        preview_widget: Widget = ...,
+        preview_widget_active: bool = ...,
+        select_multiple: bool = ...,
+        show_hidden: bool = ...,
+        use_preview_label: bool = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -19808,18 +17637,6 @@ class FileChooserButton(Box, FileChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action: FileChooserAction = ...,
-        create_folders: bool = ...,
-        do_overwrite_confirmation: bool = ...,
-        extra_widget: Widget = ...,
-        filter: FileFilter = ...,
-        local_only: bool = ...,
-        preview_widget: Widget = ...,
-        preview_widget_active: bool = ...,
-        select_multiple: bool = ...,
-        show_hidden: bool = ...,
-        use_preview_label: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_file_set(self) -> None: ...
     def get_focus_on_click(self) -> bool: ...
@@ -20116,81 +17933,8 @@ class FileChooserDialog(Dialog, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action: FileChooserAction
         create_folders: bool
         do_overwrite_confirmation: bool
@@ -20202,8 +17946,6 @@ class FileChooserDialog(Dialog, FileChooser):
         select_multiple: bool
         show_hidden: bool
         use_preview_label: bool
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -20214,6 +17956,17 @@ class FileChooserDialog(Dialog, FileChooser):
     def __init__(
         self,
         *,
+        action: FileChooserAction = ...,
+        create_folders: bool = ...,
+        do_overwrite_confirmation: bool = ...,
+        extra_widget: Widget = ...,
+        filter: FileFilter = ...,
+        local_only: bool = ...,
+        preview_widget: Widget = ...,
+        preview_widget_active: bool = ...,
+        select_multiple: bool = ...,
+        show_hidden: bool = ...,
+        use_preview_label: bool = ...,
         use_header_bar: int = ...,
         accept_focus: bool = ...,
         application: Application | None = ...,
@@ -20283,17 +18036,6 @@ class FileChooserDialog(Dialog, FileChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action: FileChooserAction = ...,
-        create_folders: bool = ...,
-        do_overwrite_confirmation: bool = ...,
-        extra_widget: Widget = ...,
-        filter: FileFilter = ...,
-        local_only: bool = ...,
-        preview_widget: Widget = ...,
-        preview_widget_active: bool = ...,
-        select_multiple: bool = ...,
-        show_hidden: bool = ...,
-        use_preview_label: bool = ...,
     ) -> None: ...
 
 class FileChooserDialogClass(_gi.Struct):
@@ -20349,13 +18091,10 @@ class FileChooserNative(NativeDialog, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(NativeDialog.Props):
         accept_label: str | None
         cancel_label: str | None
-        modal: bool
-        title: str | None
-        transient_for: Window | None
-        visible: bool
         action: FileChooserAction
         create_folders: bool
         do_overwrite_confirmation: bool
@@ -20375,10 +18114,6 @@ class FileChooserNative(NativeDialog, FileChooser):
         *,
         accept_label: str | None = ...,
         cancel_label: str | None = ...,
-        modal: bool = ...,
-        title: str = ...,
-        transient_for: Window | None = ...,
-        visible: bool = ...,
         action: FileChooserAction = ...,
         create_folders: bool = ...,
         do_overwrite_confirmation: bool = ...,
@@ -20390,6 +18125,10 @@ class FileChooserNative(NativeDialog, FileChooser):
         select_multiple: bool = ...,
         show_hidden: bool = ...,
         use_preview_label: bool = ...,
+        modal: bool = ...,
+        title: str = ...,
+        transient_for: Window | None = ...,
+        visible: bool = ...,
     ) -> None: ...
     def get_accept_label(self) -> str | None: ...
     def get_cancel_label(self) -> str | None: ...
@@ -20634,53 +18373,11 @@ class FileChooserWidget(Box, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         search_mode: bool
-        subtitle: str
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
+        @property
+        def subtitle(self) -> str: ...
         action: FileChooserAction
         create_folders: bool
         do_overwrite_confirmation: bool
@@ -20693,7 +18390,6 @@ class FileChooserWidget(Box, FileChooser):
         show_hidden: bool
         use_preview_label: bool
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -20705,6 +18401,18 @@ class FileChooserWidget(Box, FileChooser):
         self,
         *,
         search_mode: bool = ...,
+        action: FileChooserAction = ...,
+        create_folders: bool = ...,
+        do_overwrite_confirmation: bool = ...,
+        extra_widget: Widget = ...,
+        filter: FileFilter = ...,
+        local_only: bool = ...,
+        preview_widget: Widget = ...,
+        preview_widget_active: bool = ...,
+        select_multiple: bool = ...,
+        show_hidden: bool = ...,
+        use_preview_label: bool = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -20747,18 +18455,6 @@ class FileChooserWidget(Box, FileChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action: FileChooserAction = ...,
-        create_folders: bool = ...,
-        do_overwrite_confirmation: bool = ...,
-        extra_widget: Widget = ...,
-        filter: FileFilter = ...,
-        local_only: bool = ...,
-        preview_widget: Widget = ...,
-        preview_widget_active: bool = ...,
-        select_multiple: bool = ...,
-        show_hidden: bool = ...,
-        use_preview_label: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, action: FileChooserAction) -> FileChooserWidget: ...
@@ -20836,28 +18532,6 @@ class FileChooserWidgetAccessible(ContainerAccessible, Atk.Action):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -21133,52 +18807,6 @@ class Fixed(Container):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Container.Props):
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def container(self) -> Container: ...
     @property
@@ -21461,6 +19089,7 @@ class FlowBox(Container, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         activate_on_single_click: bool
         column_spacing: int
@@ -21469,49 +19098,7 @@ class FlowBox(Container, Orientable):
         min_children_per_line: int
         row_spacing: int
         selection_mode: SelectionMode
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -21527,6 +19114,7 @@ class FlowBox(Container, Orientable):
         min_children_per_line: int = ...,
         row_spacing: int = ...,
         selection_mode: SelectionMode = ...,
+        orientation: Orientation = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -21566,7 +19154,6 @@ class FlowBox(Container, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def bind_model(
         self,
@@ -21693,28 +19280,6 @@ class FlowBoxAccessible(ContainerAccessible, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -21934,52 +19499,6 @@ class FlowBoxChild(Bin):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Bin.Props):
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> Bin: ...
     def __init__(
@@ -22105,28 +19624,6 @@ class FlowBoxChildAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     def __init__(
@@ -22426,6 +19923,7 @@ class FontButton(Button, FontChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         font_name: str
         show_size: bool
@@ -22433,68 +19931,18 @@ class FontButton(Button, FontChooser):
         title: str
         use_font: bool
         use_size: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
         font: str | None
         font_desc: Pango.FontDescription | None
-        font_features: str
+        @property
+        def font_features(self) -> str: ...
         language: str
         level: FontChooserLevel
         preview_text: str
         show_preview_entry: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -22511,6 +19959,16 @@ class FontButton(Button, FontChooser):
         title: str = ...,
         use_font: bool = ...,
         use_size: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
+        font: str = ...,
+        font_desc: Pango.FontDescription = ...,
+        language: str = ...,
+        level: FontChooserLevel = ...,
+        preview_text: str = ...,
+        show_preview_entry: bool = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -22559,16 +20017,6 @@ class FontButton(Button, FontChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
-        font: str = ...,
-        font_desc: Pango.FontDescription = ...,
-        language: str = ...,
-        level: FontChooserLevel = ...,
-        preview_text: str = ...,
-        show_preview_entry: bool = ...,
     ) -> None: ...
     def do_font_set(self) -> None: ...
     def get_font_name(self) -> str: ...
@@ -22897,90 +20345,16 @@ class FontChooserDialog(Dialog, FontChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         font: str | None
         font_desc: Pango.FontDescription | None
-        font_features: str
+        @property
+        def font_features(self) -> str: ...
         language: str
         level: FontChooserLevel
         preview_text: str
         show_preview_entry: bool
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -22991,6 +20365,12 @@ class FontChooserDialog(Dialog, FontChooser):
     def __init__(
         self,
         *,
+        font: str = ...,
+        font_desc: Pango.FontDescription = ...,
+        language: str = ...,
+        level: FontChooserLevel = ...,
+        preview_text: str = ...,
+        show_preview_entry: bool = ...,
         use_header_bar: int = ...,
         accept_focus: bool = ...,
         application: Application | None = ...,
@@ -23060,12 +20440,6 @@ class FontChooserDialog(Dialog, FontChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        font: str = ...,
-        font_desc: Pango.FontDescription = ...,
-        language: str = ...,
-        level: FontChooserLevel = ...,
-        preview_text: str = ...,
-        show_preview_entry: bool = ...,
     ) -> None: ...
     @classmethod
     def new(
@@ -23306,61 +20680,19 @@ class FontChooserWidget(Box, FontChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        tweak_action: Gio.Action
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
+        @property
+        def tweak_action(self) -> Gio.Action: ...
         font: str | None
         font_desc: Pango.FontDescription | None
-        font_features: str
+        @property
+        def font_features(self) -> str: ...
         language: str
         level: FontChooserLevel
         preview_text: str
         show_preview_entry: bool
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -23371,6 +20703,13 @@ class FontChooserWidget(Box, FontChooser):
     def __init__(
         self,
         *,
+        font: str = ...,
+        font_desc: Pango.FontDescription = ...,
+        language: str = ...,
+        level: FontChooserLevel = ...,
+        preview_text: str = ...,
+        show_preview_entry: bool = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -23413,13 +20752,6 @@ class FontChooserWidget(Box, FontChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        font: str = ...,
-        font_desc: Pango.FontDescription = ...,
-        language: str = ...,
-        level: FontChooserLevel = ...,
-        preview_text: str = ...,
-        show_preview_entry: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> FontChooserWidget: ...
@@ -23630,55 +20962,11 @@ class FontSelection(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         font_name: str
         preview_text: str
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -23691,6 +20979,7 @@ class FontSelection(Box):
         *,
         font_name: str = ...,
         preview_text: str = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -23733,7 +21022,6 @@ class FontSelection(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_face(self) -> Pango.FontFace: ...
     def get_face_list(self) -> Widget: ...
@@ -24023,86 +21311,6 @@ class FontSelectionDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Dialog.Props):
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> Dialog: ...
     @property
@@ -24395,54 +21603,13 @@ class Frame(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         label: str | None
         label_widget: Widget | None
         label_xalign: float
         label_yalign: float
         shadow_type: ShadowType
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -24583,28 +21750,6 @@ class FrameAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -24841,52 +21986,15 @@ class GLArea(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         auto_render: bool
-        context: _Gdk3.GLContext
+        @property
+        def context(self) -> _Gdk3.GLContext: ...
         has_alpha: bool
         has_depth_buffer: bool
         has_stencil_buffer: bool
         use_es: bool
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -25009,11 +22117,11 @@ class Gesture(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        n_points: int
+        @property
+        def n_points(self) -> int: ...
         window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
 
     @property
     def props(self) -> Props: ...
@@ -25101,17 +22209,6 @@ class GestureDrag(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -25179,15 +22276,9 @@ class GestureLongPress(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GestureSingle.Props):
         delay_factor: float
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
 
     @property
     def props(self) -> Props: ...
@@ -25254,17 +22345,6 @@ class GestureMultiPress(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -25336,15 +22416,9 @@ class GesturePan(GestureDrag):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GestureDrag.Props):
         orientation: Orientation
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
 
     @property
     def props(self) -> Props: ...
@@ -25403,14 +22477,6 @@ class GestureRotate(Gesture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gesture.Props):
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -25465,14 +22531,11 @@ class GestureSingle(Gesture):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gesture.Props):
         button: int
         exclusive: bool
         touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
 
     @property
     def props(self) -> Props: ...
@@ -25545,17 +22608,6 @@ class GestureStylus(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -25619,17 +22671,6 @@ class GestureSwipe(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -25683,14 +22724,6 @@ class GestureZoom(Gesture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gesture.Props):
-        n_points: int
-        window: _Gdk3.Window | None
-        propagation_phase: PropagationPhase
-        widget: Widget
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -25918,55 +22951,14 @@ class Grid(Container, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         baseline_row: int
         column_homogeneous: bool
         column_spacing: int
         row_homogeneous: bool
         row_spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -25982,6 +22974,7 @@ class Grid(Container, Orientable):
         column_spacing: int = ...,
         row_homogeneous: bool = ...,
         row_spacing: int = ...,
+        orientation: Orientation = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -26021,7 +23014,6 @@ class Grid(Container, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def attach(
         self, child: Widget, left: int, top: int, width: int, height: int
@@ -26255,53 +23247,9 @@ class HBox(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -26310,6 +23258,7 @@ class HBox(Box):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -26352,7 +23301,6 @@ class HBox(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, homogeneous: bool, spacing: int) -> HBox: ...
@@ -26559,54 +23507,9 @@ class HButtonBox(ButtonBox):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ButtonBox.Props):
-        layout_style: ButtonBoxStyle
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -26615,6 +23518,7 @@ class HButtonBox(ButtonBox):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         layout_style: ButtonBoxStyle = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
@@ -26658,7 +23562,6 @@ class HButtonBox(ButtonBox):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> HButtonBox: ...
@@ -26873,55 +23776,9 @@ class HPaned(Paned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Paned.Props):
-        max_position: int
-        min_position: int
-        position: int
-        position_set: bool
-        wide_handle: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -26930,6 +23787,7 @@ class HPaned(Paned):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         position: int = ...,
         position_set: bool = ...,
         wide_handle: bool = ...,
@@ -26972,7 +23830,6 @@ class HPaned(Paned):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> HPaned: ...
@@ -27157,49 +24014,6 @@ class HSV(Widget):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Widget.Props):
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_instance(self) -> Widget: ...
     @property
@@ -27476,58 +24290,8 @@ class HScale(Scale):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Scale.Props):
-        digits: int
-        draw_value: bool
-        has_origin: bool
-        value_pos: PositionType
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        lower_stepper_sensitivity: SensitivityType
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -27537,6 +24301,7 @@ class HScale(Scale):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         digits: int = ...,
         draw_value: bool = ...,
         has_origin: bool = ...,
@@ -27585,7 +24350,6 @@ class HScale(Scale):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, adjustment: Adjustment | None = None) -> HScale: ...
@@ -27792,54 +24556,8 @@ class HScrollbar(Scrollbar):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Scrollbar.Props):
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        lower_stepper_sensitivity: SensitivityType
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -27849,6 +24567,7 @@ class HScrollbar(Scrollbar):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         fill_level: float = ...,
         inverted: bool = ...,
@@ -27893,7 +24612,6 @@ class HScrollbar(Scrollbar):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, adjustment: Adjustment | None = None) -> HScrollbar: ...
@@ -28074,46 +24792,8 @@ class HSeparator(Separator):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Separator.Props):
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -28123,6 +24803,7 @@ class HSeparator(Separator):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -28159,7 +24840,6 @@ class HSeparator(Separator):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> HSeparator: ...
@@ -28370,54 +25050,14 @@ class HandleBox(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
-        child_detached: bool
+        @property
+        def child_detached(self) -> bool: ...
         handle_position: PositionType
         shadow_type: ShadowType
         snap_edge: PositionType
         snap_edge_set: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -28698,57 +25338,16 @@ class HeaderBar(Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         custom_title: Widget | None
-        decoration_layout: str
+        decoration_layout: str | None
         decoration_layout_set: bool
         has_subtitle: bool
         show_close_button: bool
         spacing: int
         subtitle: str | None
         title: str | None
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -28895,28 +25494,6 @@ class HeaderBarAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     def __init__(
@@ -28992,6 +25569,7 @@ class IMContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         input_hints: InputHints
         input_purpose: InputPurpose
@@ -29119,12 +25697,6 @@ class IMContextSimple(IMContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(IMContext.Props):
-        input_hints: InputHints
-        input_purpose: InputPurpose
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> IMContext: ...
     @property
@@ -29177,12 +25749,6 @@ class IMMulticontext(IMContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(IMContext.Props):
-        input_hints: InputHints
-        input_purpose: InputPurpose
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> IMContext: ...
     @property
@@ -29721,9 +26287,11 @@ class IconView(Container, CellLayout, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         activate_on_single_click: bool
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         column_spacing: int
         columns: int
         item_orientation: Orientation
@@ -29739,51 +26307,10 @@ class IconView(Container, CellLayout, Scrollable):
         spacing: int
         text_column: int
         tooltip_column: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscroll_policy: ScrollablePolicy
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -29811,6 +26338,10 @@ class IconView(Container, CellLayout, Scrollable):
         spacing: int = ...,
         text_column: int = ...,
         tooltip_column: int = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -29849,10 +26380,6 @@ class IconView(Container, CellLayout, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def convert_widget_to_bin_window_coords(
         self, wx: int, wy: int
@@ -30033,28 +26560,6 @@ class IconViewAccessible(ContainerAccessible, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -30333,6 +26838,7 @@ class Image(Misc):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Misc.Props):
         file: str
         gicon: Gio.Icon
@@ -30344,52 +26850,10 @@ class Image(Misc):
         pixel_size: int
         resource: str
         stock: str
-        storage_type: ImageType
+        @property
+        def storage_type(self) -> ImageType: ...
         surface: cairo.Surface
         use_fallback: bool
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -30563,28 +27027,6 @@ class ImageAccessible(WidgetAccessible, Atk.Image):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -30699,29 +27141,6 @@ class ImageCellAccessible(RendererCellAccessible, Atk.Image):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RendererCellAccessible.Props):
-        renderer: CellRenderer
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RendererCellAccessible: ...
     @property
@@ -30983,62 +27402,16 @@ class ImageMenuItem(MenuItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MenuItem.Props):
+        accel_group: AccelGroup
         always_show_image: bool
-        image: Widget
+        image: Widget | None
         use_stock: bool
-        accel_path: str | None
-        label: str
-        right_justified: bool
-        submenu: Menu | None
-        use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        accel_group: AccelGroup
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -31053,6 +27426,10 @@ class ImageMenuItem(MenuItem):
         always_show_image: bool = ...,
         image: Widget | None = ...,
         use_stock: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         accel_path: str | None = ...,
         label: str = ...,
         right_justified: bool = ...,
@@ -31097,10 +27474,6 @@ class ImageMenuItem(MenuItem):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def get_always_show_image(self) -> bool: ...
     def get_image(self) -> Widget: ...
@@ -31333,56 +27706,12 @@ class InfoBar(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         message_type: MessageType
         revealed: bool
         show_close_button: bool
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -31396,6 +27725,7 @@ class InfoBar(Box):
         message_type: MessageType = ...,
         revealed: bool = ...,
         show_close_button: bool = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -31438,7 +27768,6 @@ class InfoBar(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_action_widget(self, child: Widget, response_id: int) -> None: ...
     def add_button(self, button_text: str, response_id: int) -> Button: ...
@@ -31645,47 +27974,9 @@ class Invisible(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         screen: _Gdk3.Screen
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -31983,19 +28274,24 @@ class Label(Misc):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Misc.Props):
         angle: float
         attributes: Pango.AttrList | None
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         ellipsize: Pango.EllipsizeMode
         justify: Justification
         label: str
         lines: int
         max_width_chars: int
-        mnemonic_keyval: int
+        @property
+        def mnemonic_keyval(self) -> int: ...
         mnemonic_widget: Widget | None
+        pattern: str
         selectable: bool
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         single_line_mode: bool
         track_visited_links: bool
         use_markup: bool
@@ -32005,48 +28301,6 @@ class Label(Misc):
         wrap_mode: Pango.WrapMode
         xalign: float
         yalign: float
-        xpad: int
-        ypad: int
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        pattern: str
 
     @property
     def props(self) -> Props: ...
@@ -32255,28 +28509,6 @@ class LabelAccessible(WidgetAccessible, Atk.Hypertext, Atk.Text):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -32521,55 +28753,14 @@ class Layout(Container, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         height: int
         width: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscroll_policy: ScrollablePolicy
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -32582,6 +28773,10 @@ class Layout(Container, Scrollable):
         *,
         height: int = ...,
         width: int = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -32621,10 +28816,6 @@ class Layout(Container, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def get_bin_window(self) -> _Gdk3.Window: ...
     def get_hadjustment(self) -> Adjustment: ...
@@ -32836,51 +29027,13 @@ class LevelBar(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         inverted: bool
         max_value: float
         min_value: float
         mode: LevelBarMode
         value: float
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -32897,6 +29050,7 @@ class LevelBar(Widget, Orientable):
         min_value: float = ...,
         mode: LevelBarMode = ...,
         value: float = ...,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -32933,7 +29087,6 @@ class LevelBar(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_offset_value(self, name: str, value: float) -> None: ...
     def do_offset_changed(self, name: str) -> None: ...
@@ -33027,28 +29180,6 @@ class LevelBarAccessible(WidgetAccessible, Atk.Value):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -33320,64 +29451,14 @@ class LinkButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         uri: str
         visited: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -33390,6 +29471,10 @@ class LinkButton(Button):
         *,
         uri: str = ...,
         visited: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -33438,10 +29523,6 @@ class LinkButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_activate_link(self) -> bool: ...
     def get_uri(self) -> str: ...
@@ -33529,28 +29610,6 @@ class LinkButtonAccessible(ButtonAccessible, Atk.HyperlinkImpl):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ButtonAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ButtonAccessible: ...
     @property
@@ -33798,51 +29857,10 @@ class ListBox(Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         activate_on_single_click: bool
         selection_mode: SelectionMode
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -34019,28 +30037,6 @@ class ListBoxAccessible(ContainerAccessible, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -34293,53 +30289,12 @@ class ListBoxRow(Bin, Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         activatable: bool
         selectable: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -34350,6 +30305,8 @@ class ListBoxRow(Bin, Actionable):
         *,
         activatable: bool = ...,
         selectable: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -34389,8 +30346,6 @@ class ListBoxRow(Bin, Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def changed(self) -> None: ...
     def do_activate(self) -> None: ...
@@ -34478,28 +30433,6 @@ class ListBoxRowAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     def __init__(
@@ -34844,68 +30777,18 @@ class LockButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
-        permission: Gio.Permission
+        permission: Gio.Permission | None
         text_lock: str
         text_unlock: str
         tooltip_lock: str
         tooltip_not_authorized: str
         tooltip_unlock: str
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -34922,6 +30805,10 @@ class LockButton(Button):
         tooltip_lock: str = ...,
         tooltip_not_authorized: str = ...,
         tooltip_unlock: str = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -34970,10 +30857,6 @@ class LockButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def get_permission(self) -> Gio.Permission: ...
     @classmethod
@@ -35056,28 +30939,6 @@ class LockButtonAccessible(ButtonAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ButtonAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ButtonAccessible: ...
     @property
@@ -35368,9 +31229,10 @@ class Menu(MenuShell):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MenuShell.Props):
-        accel_group: AccelGroup
-        accel_path: str
+        accel_group: AccelGroup | None
+        accel_path: str | None
         active: int
         anchor_hints: _Gdk3.AnchorHints
         attach_widget: Widget
@@ -35381,49 +31243,6 @@ class Menu(MenuShell):
         reserve_toggle_size: bool
         tearoff_state: bool
         tearoff_title: str
-        take_focus: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -35646,28 +31465,6 @@ class MenuAccessible(MenuShellAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(MenuShellAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> MenuShellAccessible: ...
     @property
@@ -35905,52 +31702,10 @@ class MenuBar(MenuShell):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MenuShell.Props):
         child_pack_direction: PackDirection
         pack_direction: PackDirection
-        take_focus: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -36258,6 +32013,7 @@ class MenuButton(ToggleButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToggleButton.Props):
         align_widget: Container | None
         direction: ArrowType
@@ -36265,64 +32021,10 @@ class MenuButton(ToggleButton):
         popover: Popover | None
         popup: Menu | None
         use_popover: bool
-        active: bool
-        draw_indicator: bool
-        inconsistent: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -36339,6 +32041,10 @@ class MenuButton(ToggleButton):
         popover: Popover | None = ...,
         popup: Menu | None = ...,
         use_popover: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         active: bool = ...,
         draw_indicator: bool = ...,
         inconsistent: bool = ...,
@@ -36390,10 +32096,6 @@ class MenuButton(ToggleButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def get_align_widget(self) -> Widget | None: ...
     def get_direction(self) -> ArrowType: ...
@@ -36489,28 +32191,6 @@ class MenuButtonAccessible(ToggleButtonAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ToggleButtonAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ToggleButtonAccessible: ...
     @property
@@ -36773,58 +32453,17 @@ class MenuItem(Bin, Actionable, Activatable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         accel_path: str | None
         label: str
         right_justified: bool
         submenu: Menu | None
         use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -36840,6 +32479,10 @@ class MenuItem(Bin, Actionable, Activatable):
         right_justified: bool = ...,
         submenu: Menu | None = ...,
         use_underline: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -36879,10 +32522,6 @@ class MenuItem(Bin, Actionable, Activatable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def activate(self) -> None: ...
     def deselect(self) -> None: ...
@@ -36992,28 +32631,6 @@ class MenuItemAccessible(ContainerAccessible, Atk.Action, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -37275,50 +32892,9 @@ class MenuShell(Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         take_focus: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -37475,28 +33051,6 @@ class MenuShellAccessible(ContainerAccessible, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -37783,63 +33337,13 @@ class MenuToolButton(ToolButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToolButton.Props):
         menu: Menu
-        icon_name: str | None
-        icon_widget: Widget | None
-        label: str | None
-        label_widget: Widget | None
-        stock_id: str
-        use_underline: bool
-        is_important: bool
-        visible_horizontal: bool
-        visible_vertical: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -37851,6 +33355,10 @@ class MenuToolButton(ToolButton):
         self,
         *,
         menu: Menu = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         icon_name: str | None = ...,
         icon_widget: Widget | None = ...,
         label: str | None = ...,
@@ -37899,10 +33407,6 @@ class MenuToolButton(ToolButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_show_menu(self) -> None: ...
     def get_menu(self) -> Widget: ...
@@ -37931,7 +33435,7 @@ class MenuToolButtonClass(_gi.Struct):
 
 class MenuToolButtonPrivate(_gi.Struct): ...
 
-class MessageDialog(Dialog, Dialog):
+class MessageDialog(Dialog):
     """
     :Constructors:
 
@@ -38210,91 +33714,16 @@ class MessageDialog(Dialog, Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         image: Widget
-        message_area: Widget
+        @property
+        def message_area(self) -> Widget: ...
         message_type: MessageType
         secondary_text: str
         secondary_use_markup: bool
         text: str
         use_markup: bool
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        buttons: ButtonsType
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -38578,50 +34007,12 @@ class Misc(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         xalign: float
         xpad: int
         yalign: float
         ypad: int
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -38918,6 +34309,7 @@ class ModelButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         active: bool
         centered: bool
@@ -38928,61 +34320,10 @@ class ModelButton(Button):
         role: ButtonRole
         text: str
         use_markup: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -38998,6 +34339,10 @@ class ModelButton(Button):
         role: ButtonRole = ...,
         text: str = ...,
         use_markup: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -39046,10 +34391,6 @@ class ModelButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> ModelButton: ...
@@ -39095,19 +34436,12 @@ class MountOperation(Gio.MountOperation):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.MountOperation.Props):
-        is_showing: bool
-        parent: Window
+        @property
+        def is_showing(self) -> bool: ...
+        parent: Window | None
         screen: _Gdk3.Screen
-        anonymous: bool
-        choice: int
-        domain: str | None
-        is_tcrypt_hidden_volume: bool
-        is_tcrypt_system_volume: bool
-        password: str | None
-        password_save: Gio.PasswordSave
-        pim: int
-        username: str | None
 
     @property
     def props(self) -> Props: ...
@@ -39177,6 +34511,7 @@ class NativeDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         modal: bool
         title: str | None
@@ -39434,6 +34769,7 @@ class Notebook(Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         enable_popup: bool
         group_name: str | None
@@ -39442,48 +34778,6 @@ class Notebook(Container):
         show_border: bool
         show_tabs: bool
         tab_pos: PositionType
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -39696,28 +34990,6 @@ class NotebookAccessible(ContainerAccessible, Atk.Selection):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -39852,27 +35124,6 @@ class NotebookPageAccessible(Atk.Object, Atk.Component):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Atk.Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Atk.Object: ...
     @property
@@ -39943,13 +35194,13 @@ class NumerableIcon(Gio.EmblemedIcon):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.EmblemedIcon.Props):
         background_icon: Gio.Icon
         background_icon_name: str | None
         count: int
         label: str | None
         style_context: StyleContext | None
-        gicon: Gio.Icon
 
     @property
     def props(self) -> Props: ...
@@ -40253,85 +35504,6 @@ class OffscreenWindow(Window):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Window.Props):
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent_object(self) -> Window: ...
     def __init__(
@@ -40625,52 +35797,6 @@ class Overlay(Bin):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Bin.Props):
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Bin: ...
     @property
@@ -40786,11 +35912,12 @@ class PadController(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        action_group: Gio.ActionGroup
-        pad: _Gdk3.Device
-        propagation_phase: PropagationPhase
-        widget: Widget
+        @property
+        def action_group(self) -> Gio.ActionGroup: ...
+        @property
+        def pad(self) -> _Gdk3.Device: ...
 
     @property
     def props(self) -> Props: ...
@@ -41079,55 +36206,16 @@ class Paned(Container, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
-        max_position: int
-        min_position: int
+        @property
+        def max_position(self) -> int: ...
+        @property
+        def min_position(self) -> int: ...
         position: int
         position_set: bool
         wide_handle: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -41141,6 +36229,7 @@ class Paned(Container, Orientable):
         position: int = ...,
         position_set: bool = ...,
         wide_handle: bool = ...,
+        orientation: Orientation = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -41180,7 +36269,6 @@ class Paned(Container, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add1(self, child: Widget) -> None: ...
     def add2(self, child: Widget) -> None: ...
@@ -41280,28 +36368,6 @@ class PanedAccessible(ContainerAccessible, Atk.Value):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -41675,6 +36741,7 @@ class PlacesSidebar(ScrolledWindow):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ScrolledWindow.Props):
         local_only: bool
         location: Gio.File | None
@@ -41687,63 +36754,6 @@ class PlacesSidebar(ScrolledWindow):
         show_recent: bool
         show_starred_location: bool
         show_trash: bool
-        hadjustment: Adjustment
-        hscrollbar_policy: PolicyType
-        kinetic_scrolling: bool
-        max_content_height: int
-        max_content_width: int
-        min_content_height: int
-        min_content_width: int
-        overlay_scrolling: bool
-        propagate_natural_height: bool
-        propagate_natural_width: bool
-        shadow_type: ShadowType
-        vadjustment: Adjustment
-        vscrollbar_policy: PolicyType
-        window_placement: CornerType
-        window_placement_set: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -42112,84 +37122,12 @@ class Plug(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
-        embedded: bool
-        socket_window: _Gdk3.Window | None
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
+        @property
+        def embedded(self) -> bool: ...
+        @property
+        def socket_window(self) -> _Gdk3.Window | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -42378,28 +37316,6 @@ class PlugAccessible(WindowAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WindowAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WindowAccessible: ...
     @property
@@ -42650,55 +37566,14 @@ class Popover(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         constrain_to: PopoverConstraint
         modal: bool
         pointing_to: _Gdk3.Rectangle
         position: PositionType
-        relative_to: Widget
+        relative_to: Widget | None
         transitions_enabled: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -42855,28 +37730,6 @@ class PopoverAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     def __init__(
@@ -43125,56 +37978,9 @@ class PopoverMenu(Popover):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Popover.Props):
         visible_submenu: str
-        constrain_to: PopoverConstraint
-        modal: bool
-        pointing_to: _Gdk3.Rectangle
-        position: PositionType
-        relative_to: Widget
-        transitions_enabled: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -43343,21 +38149,25 @@ class PrintOperation(GObject.Object, PrintOperationPreview):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         allow_async: bool
         current_page: int
         custom_tab_label: str | None
-        default_page_setup: PageSetup
+        default_page_setup: PageSetup | None
         embed_page_setup: bool
         export_filename: str
         has_selection: bool
         job_name: str
         n_pages: int
-        n_pages_to_print: int
-        print_settings: PrintSettings
+        @property
+        def n_pages_to_print(self) -> int: ...
+        print_settings: PrintSettings | None
         show_progress: bool
-        status: PrintStatus
-        status_string: str
+        @property
+        def status(self) -> PrintStatus: ...
+        @property
+        def status_string(self) -> str: ...
         support_selection: bool
         track_print_status: bool
         unit: Unit
@@ -43802,6 +38612,7 @@ class ProgressBar(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         ellipsize: Pango.EllipsizeMode
         fraction: float
@@ -43809,45 +38620,6 @@ class ProgressBar(Widget, Orientable):
         pulse_step: float
         show_text: bool
         text: str | None
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -43865,6 +38637,7 @@ class ProgressBar(Widget, Orientable):
         pulse_step: float = ...,
         show_text: bool = ...,
         text: str | None = ...,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -43901,7 +38674,6 @@ class ProgressBar(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_ellipsize(self) -> Pango.EllipsizeMode: ...
     def get_fraction(self) -> float: ...
@@ -43992,28 +38764,6 @@ class ProgressBarAccessible(WidgetAccessible, Atk.Value):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -44136,28 +38886,11 @@ class RadioAction(ToggleAction):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToggleAction.Props):
         current_value: int
-        value: int
-        active: bool
-        draw_as_radio: bool
-        action_group: ActionGroup
-        always_show_image: bool
-        gicon: Gio.Icon
-        hide_if_empty: bool
-        icon_name: str
-        is_important: bool
-        label: str
-        name: str
-        sensitive: bool
-        short_label: str
-        stock_id: str
-        tooltip: str
-        visible: bool
-        visible_horizontal: bool
-        visible_overflown: bool
-        visible_vertical: bool
         group: RadioAction | None
+        value: int
 
     @property
     def props(self) -> Props: ...
@@ -44467,66 +39200,13 @@ class RadioButton(CheckButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CheckButton.Props):
-        active: bool
-        draw_indicator: bool
-        inconsistent: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
+        group: RadioButton | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        group: RadioButton | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -44538,6 +39218,10 @@ class RadioButton(CheckButton):
         self,
         *,
         group: RadioButton | None = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         active: bool = ...,
         draw_indicator: bool = ...,
         inconsistent: bool = ...,
@@ -44589,10 +39273,6 @@ class RadioButton(CheckButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_group_changed(self) -> None: ...
     def get_group(self) -> list[RadioButton]: ...
@@ -44700,28 +39380,6 @@ class RadioButtonAccessible(ToggleButtonAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ToggleButtonAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ToggleButtonAccessible: ...
     @property
@@ -44996,62 +39654,13 @@ class RadioMenuItem(CheckMenuItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CheckMenuItem.Props):
-        active: bool
-        draw_as_radio: bool
-        inconsistent: bool
-        accel_path: str | None
-        label: str
-        right_justified: bool
-        submenu: Menu | None
-        use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
+        group: RadioMenuItem | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        group: RadioMenuItem | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -45063,6 +39672,10 @@ class RadioMenuItem(CheckMenuItem):
         self,
         *,
         group: RadioMenuItem | None = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         active: bool = ...,
         draw_as_radio: bool = ...,
         inconsistent: bool = ...,
@@ -45110,10 +39723,6 @@ class RadioMenuItem(CheckMenuItem):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_group_changed(self) -> None: ...
     def get_group(self) -> list[RadioMenuItem]: ...
@@ -45228,28 +39837,6 @@ class RadioMenuItemAccessible(CheckMenuItemAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(CheckMenuItemAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> CheckMenuItemAccessible: ...
     @property
@@ -45524,64 +40111,13 @@ class RadioToolButton(ToggleToolButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToggleToolButton.Props):
-        active: bool
-        icon_name: str | None
-        icon_widget: Widget | None
-        label: str | None
-        label_widget: Widget | None
-        stock_id: str
-        use_underline: bool
-        is_important: bool
-        visible_horizontal: bool
-        visible_vertical: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
+        group: RadioToolButton | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        group: RadioToolButton | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -45591,6 +40127,10 @@ class RadioToolButton(ToggleToolButton):
         self,
         *,
         group: RadioToolButton | None = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         active: bool = ...,
         icon_name: str | None = ...,
         icon_widget: Widget | None = ...,
@@ -45640,10 +40180,6 @@ class RadioToolButton(ToggleToolButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def get_group(self) -> list[RadioButton]: ...
     @classmethod
@@ -45861,6 +40397,7 @@ class Range(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         adjustment: Adjustment
         fill_level: float
@@ -45870,45 +40407,6 @@ class Range(Widget, Orientable):
         round_digits: int
         show_fill_level: bool
         upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -45928,6 +40426,7 @@ class Range(Widget, Orientable):
         round_digits: int = ...,
         show_fill_level: bool = ...,
         upper_stepper_sensitivity: SensitivityType = ...,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -45964,7 +40463,6 @@ class Range(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_adjust_bounds(self, new_value: float) -> None: ...
     def do_change_value(self, scroll: ScrollType, new_value: float) -> bool: ...
@@ -46076,28 +40574,6 @@ class RangeAccessible(WidgetAccessible, Atk.Value):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -46330,25 +40806,10 @@ class RecentAction(Action, RecentChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Action.Props):
         show_numbers: bool
-        action_group: ActionGroup
-        always_show_image: bool
-        gicon: Gio.Icon
-        hide_if_empty: bool
-        icon_name: str
-        is_important: bool
-        label: str
-        name: str
-        sensitive: bool
-        short_label: str
-        stock_id: str
-        tooltip: str
-        visible: bool
-        visible_horizontal: bool
-        visible_overflown: bool
-        visible_vertical: bool
-        filter: RecentFilter
+        filter: RecentFilter | None
         limit: int
         local_only: bool
         select_multiple: bool
@@ -46357,7 +40818,6 @@ class RecentAction(Action, RecentChooser):
         show_private: bool
         show_tips: bool
         sort_type: RecentSortType
-        recent_manager: RecentManager
 
     @property
     def props(self) -> Props: ...
@@ -46369,6 +40829,16 @@ class RecentAction(Action, RecentChooser):
         self,
         *,
         show_numbers: bool = ...,
+        filter: RecentFilter | None = ...,
+        limit: int = ...,
+        local_only: bool = ...,
+        recent_manager: RecentManager = ...,
+        select_multiple: bool = ...,
+        show_icons: bool = ...,
+        show_not_found: bool = ...,
+        show_private: bool = ...,
+        show_tips: bool = ...,
+        sort_type: RecentSortType = ...,
         action_group: ActionGroup = ...,
         always_show_image: bool = ...,
         gicon: Gio.Icon = ...,
@@ -46385,16 +40855,6 @@ class RecentAction(Action, RecentChooser):
         visible_horizontal: bool = ...,
         visible_overflown: bool = ...,
         visible_vertical: bool = ...,
-        filter: RecentFilter | None = ...,
-        limit: int = ...,
-        local_only: bool = ...,
-        recent_manager: RecentManager = ...,
-        select_multiple: bool = ...,
-        show_icons: bool = ...,
-        show_not_found: bool = ...,
-        show_private: bool = ...,
-        show_tips: bool = ...,
-        sort_type: RecentSortType = ...,
     ) -> None: ...
     def get_show_numbers(self) -> bool: ...
     @classmethod
@@ -46733,82 +41193,9 @@ class RecentChooserDialog(Dialog, RecentChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        use_header_bar: int
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        filter: RecentFilter
+        filter: RecentFilter | None
         limit: int
         local_only: bool
         select_multiple: bool
@@ -46817,9 +41204,6 @@ class RecentChooserDialog(Dialog, RecentChooser):
         show_private: bool
         show_tips: bool
         sort_type: RecentSortType
-        startup_id: str
-        child: Widget
-        recent_manager: RecentManager
 
     @property
     def props(self) -> Props: ...
@@ -46830,6 +41214,16 @@ class RecentChooserDialog(Dialog, RecentChooser):
     def __init__(
         self,
         *,
+        filter: RecentFilter | None = ...,
+        limit: int = ...,
+        local_only: bool = ...,
+        recent_manager: RecentManager = ...,
+        select_multiple: bool = ...,
+        show_icons: bool = ...,
+        show_not_found: bool = ...,
+        show_private: bool = ...,
+        show_tips: bool = ...,
+        sort_type: RecentSortType = ...,
         use_header_bar: int = ...,
         accept_focus: bool = ...,
         application: Application | None = ...,
@@ -46899,16 +41293,6 @@ class RecentChooserDialog(Dialog, RecentChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        filter: RecentFilter | None = ...,
-        limit: int = ...,
-        local_only: bool = ...,
-        recent_manager: RecentManager = ...,
-        select_multiple: bool = ...,
-        show_icons: bool = ...,
-        show_not_found: bool = ...,
-        show_private: bool = ...,
-        show_tips: bool = ...,
-        sort_type: RecentSortType = ...,
     ) -> None: ...
 
 class RecentChooserDialogClass(_gi.Struct):
@@ -47195,65 +41579,12 @@ class RecentChooserMenu(Menu, Activatable, RecentChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Menu.Props):
         show_numbers: bool
-        accel_group: AccelGroup
-        accel_path: str
-        active: int
-        anchor_hints: _Gdk3.AnchorHints
-        attach_widget: Widget
-        menu_type_hint: _Gdk3.WindowTypeHint
-        monitor: int
-        rect_anchor_dx: int
-        rect_anchor_dy: int
-        reserve_toggle_size: bool
-        tearoff_state: bool
-        tearoff_title: str
-        take_focus: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         related_action: Action
         use_action_appearance: bool
-        filter: RecentFilter
+        filter: RecentFilter | None
         limit: int
         local_only: bool
         select_multiple: bool
@@ -47262,8 +41593,6 @@ class RecentChooserMenu(Menu, Activatable, RecentChooser):
         show_private: bool
         show_tips: bool
         sort_type: RecentSortType
-        child: Widget
-        recent_manager: RecentManager
 
     @property
     def props(self) -> Props: ...
@@ -47275,6 +41604,18 @@ class RecentChooserMenu(Menu, Activatable, RecentChooser):
         self,
         *,
         show_numbers: bool = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
+        filter: RecentFilter | None = ...,
+        limit: int = ...,
+        local_only: bool = ...,
+        recent_manager: RecentManager = ...,
+        select_multiple: bool = ...,
+        show_icons: bool = ...,
+        show_not_found: bool = ...,
+        show_private: bool = ...,
+        show_tips: bool = ...,
+        sort_type: RecentSortType = ...,
         accel_group: AccelGroup | None = ...,
         accel_path: str | None = ...,
         active: int = ...,
@@ -47327,18 +41668,6 @@ class RecentChooserMenu(Menu, Activatable, RecentChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
-        filter: RecentFilter | None = ...,
-        limit: int = ...,
-        local_only: bool = ...,
-        recent_manager: RecentManager = ...,
-        select_multiple: bool = ...,
-        show_icons: bool = ...,
-        show_not_found: bool = ...,
-        show_private: bool = ...,
-        show_tips: bool = ...,
-        sort_type: RecentSortType = ...,
     ) -> None: ...
     def get_show_numbers(self) -> bool: ...
     @classmethod
@@ -47560,53 +41889,10 @@ class RecentChooserWidget(Box, RecentChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        filter: RecentFilter
+        filter: RecentFilter | None
         limit: int
         local_only: bool
         select_multiple: bool
@@ -47615,8 +41901,6 @@ class RecentChooserWidget(Box, RecentChooser):
         show_private: bool
         show_tips: bool
         sort_type: RecentSortType
-        child: Widget
-        recent_manager: RecentManager
 
     @property
     def props(self) -> Props: ...
@@ -47627,6 +41911,17 @@ class RecentChooserWidget(Box, RecentChooser):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
+        filter: RecentFilter | None = ...,
+        limit: int = ...,
+        local_only: bool = ...,
+        recent_manager: RecentManager = ...,
+        select_multiple: bool = ...,
+        show_icons: bool = ...,
+        show_not_found: bool = ...,
+        show_private: bool = ...,
+        show_tips: bool = ...,
+        sort_type: RecentSortType = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -47669,17 +41964,6 @@ class RecentChooserWidget(Box, RecentChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
-        filter: RecentFilter | None = ...,
-        limit: int = ...,
-        local_only: bool = ...,
-        recent_manager: RecentManager = ...,
-        select_multiple: bool = ...,
-        show_icons: bool = ...,
-        show_not_found: bool = ...,
-        show_private: bool = ...,
-        show_tips: bool = ...,
-        sort_type: RecentSortType = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> RecentChooserWidget: ...
@@ -47815,9 +42099,12 @@ class RecentManager(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        filename: str
-        size: int
+        @property
+        def filename(self) -> str: ...
+        @property
+        def size(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -47930,26 +42217,10 @@ class RendererCellAccessible(CellAccessible):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellAccessible.Props):
-        renderer: CellRenderer
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
+        @property
+        def renderer(self) -> CellRenderer: ...
 
     @property
     def props(self) -> Props: ...
@@ -48214,53 +42485,13 @@ class Revealer(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
-        child_revealed: bool
+        @property
+        def child_revealed(self) -> bool: ...
         reveal_child: bool
         transition_duration: int
         transition_type: RevealerTransitionType
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -48536,58 +42767,12 @@ class Scale(Range):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Range.Props):
         digits: int
         draw_value: bool
         has_origin: bool
         value_pos: PositionType
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        lower_stepper_sensitivity: SensitivityType
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -48603,6 +42788,7 @@ class Scale(Range):
         draw_value: bool = ...,
         has_origin: bool = ...,
         value_pos: PositionType = ...,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         fill_level: float = ...,
         inverted: bool = ...,
@@ -48647,7 +42833,6 @@ class Scale(Range):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_mark(
         self, value: float, position: PositionType, markup: str | None = None
@@ -48754,28 +42939,6 @@ class ScaleAccessible(RangeAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RangeAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RangeAccessible: ...
     @property
@@ -49035,67 +43198,17 @@ class ScaleButton(Button, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         adjustment: Adjustment
         icons: list[str]
         size: IconSize
         value: float
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -49110,6 +43223,11 @@ class ScaleButton(Button, Orientable):
         icons: Sequence[str] = ...,
         size: IconSize = ...,
         value: float = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
+        orientation: Orientation = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -49158,11 +43276,6 @@ class ScaleButton(Button, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_value_changed(self, value: float) -> None: ...
     def get_adjustment(self) -> Adjustment: ...
@@ -49262,28 +43375,6 @@ class ScaleButtonAccessible(ButtonAccessible, Atk.Value):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ButtonAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ButtonAccessible: ...
     @property
@@ -49574,54 +43665,8 @@ class Scrollbar(Range):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Range.Props):
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        lower_stepper_sensitivity: SensitivityType
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -49631,6 +43676,7 @@ class Scrollbar(Range):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         fill_level: float = ...,
         inverted: bool = ...,
@@ -49675,7 +43721,6 @@ class Scrollbar(Range):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(
@@ -49910,8 +43955,9 @@ class ScrolledWindow(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         hscrollbar_policy: PolicyType
         kinetic_scrolling: bool
         max_content_height: int
@@ -49922,52 +43968,10 @@ class ScrolledWindow(Bin):
         propagate_natural_height: bool
         propagate_natural_width: bool
         shadow_type: ShadowType
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscrollbar_policy: PolicyType
         window_placement: CornerType
         window_placement_set: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -50149,28 +44153,6 @@ class ScrolledWindowAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -50412,51 +44394,10 @@ class SearchBar(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         search_mode_enabled: bool
         show_close_button: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -50837,97 +44778,8 @@ class SearchEntry(Entry):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Entry.Props):
-        activates_default: bool
-        attributes: Pango.AttrList | None
-        buffer: EntryBuffer
-        caps_lock_warning: bool
-        completion: EntryCompletion
-        cursor_position: int
-        editable: bool
-        enable_emoji_completion: bool
-        has_frame: bool
-        im_module: str
-        inner_border: Border | None
-        input_hints: InputHints
-        input_purpose: InputPurpose
-        invisible_char: int
-        invisible_char_set: bool
-        max_length: int
-        max_width_chars: int
-        overwrite_mode: bool
-        placeholder_text: str
-        populate_all: bool
-        primary_icon_activatable: bool
-        primary_icon_gicon: Gio.Icon
-        primary_icon_name: str
-        primary_icon_pixbuf: GdkPixbuf.Pixbuf
-        primary_icon_sensitive: bool
-        primary_icon_stock: str
-        primary_icon_storage_type: ImageType
-        primary_icon_tooltip_markup: str
-        primary_icon_tooltip_text: str
-        progress_fraction: float
-        progress_pulse_step: float
-        scroll_offset: int
-        secondary_icon_activatable: bool
-        secondary_icon_gicon: Gio.Icon
-        secondary_icon_name: str
-        secondary_icon_pixbuf: GdkPixbuf.Pixbuf
-        secondary_icon_sensitive: bool
-        secondary_icon_stock: str
-        secondary_icon_storage_type: ImageType
-        secondary_icon_tooltip_markup: str
-        secondary_icon_tooltip_text: str
-        selection_bound: int
-        shadow_type: ShadowType
-        show_emoji_icon: bool
-        tabs: Pango.TabArray | None
-        text: str
-        text_length: int
-        truncate_multiline: bool
-        visibility: bool
-        width_chars: int
-        xalign: float
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         editing_canceled: bool
 
     @property
@@ -50937,6 +44789,7 @@ class SearchEntry(Entry):
     def __init__(
         self,
         *,
+        editing_canceled: bool = ...,
         activates_default: bool = ...,
         attributes: Pango.AttrList = ...,
         buffer: EntryBuffer = ...,
@@ -51018,7 +44871,6 @@ class SearchEntry(Entry):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def do_next_match(self) -> None: ...
     def do_previous_match(self) -> None: ...
@@ -51235,46 +45087,8 @@ class Separator(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -51286,6 +45100,7 @@ class Separator(Widget, Orientable):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -51322,7 +45137,6 @@ class Separator(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, orientation: Orientation) -> Separator: ...
@@ -51537,58 +45351,12 @@ class SeparatorMenuItem(MenuItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MenuItem.Props):
-        accel_path: str | None
-        label: str
-        right_justified: bool
-        submenu: Menu | None
-        use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -51597,6 +45365,10 @@ class SeparatorMenuItem(MenuItem):
     def __init__(
         self,
         *,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         accel_path: str | None = ...,
         label: str = ...,
         right_justified: bool = ...,
@@ -51641,10 +45413,6 @@ class SeparatorMenuItem(MenuItem):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> SeparatorMenuItem: ...
@@ -51857,55 +45625,11 @@ class SeparatorToolItem(ToolItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToolItem.Props):
         draw: bool
-        is_important: bool
-        visible_horizontal: bool
-        visible_vertical: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -51917,6 +45641,8 @@ class SeparatorToolItem(ToolItem):
         self,
         *,
         draw: bool = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         is_important: bool = ...,
         visible_horizontal: bool = ...,
         visible_vertical: bool = ...,
@@ -51959,8 +45685,6 @@ class SeparatorToolItem(ToolItem):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def get_draw(self) -> bool: ...
     @classmethod
@@ -52168,8 +45892,10 @@ class Settings(GObject.Object, StyleProvider):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        color_hash: dict[str, _Gdk3.Color]
+        @property
+        def color_hash(self) -> dict[str, _Gdk3.Color]: ...
         gtk_alternative_button_order: bool
         gtk_alternative_sort_arrows: bool
         gtk_application_prefer_dark_theme: bool
@@ -52584,55 +46310,11 @@ class ShortcutLabel(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         accelerator: str | None
         disabled_text: str | None
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -52641,6 +46323,7 @@ class ShortcutLabel(Box):
         *,
         accelerator: str = ...,
         disabled_text: str = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -52683,7 +46366,6 @@ class ShortcutLabel(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_accelerator(self) -> str | None: ...
     def get_disabled_text(self) -> str | None: ...
@@ -52892,58 +46574,15 @@ class ShortcutsGroup(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        height: int
-        title: str
-        view: str
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        orientation: Orientation
         accel_size_group: SizeGroup
+        @property
+        def height(self) -> int: ...
+        title: str
         title_size_group: SizeGroup
-        child: Widget
+        view: str
+        orientation: Orientation
 
     @property
     def props(self) -> Props: ...
@@ -52954,6 +46593,7 @@ class ShortcutsGroup(Box):
         title: str = ...,
         title_size_group: SizeGroup = ...,
         view: str = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -52996,7 +46636,6 @@ class ShortcutsGroup(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
 
 class ShortcutsGroupClass(_gi.Struct): ...
@@ -53200,57 +46839,13 @@ class ShortcutsSection(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         max_height: int
         section_name: str
         title: str
         view_name: str
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -53261,6 +46856,7 @@ class ShortcutsSection(Box):
         section_name: str = ...,
         title: str = ...,
         view_name: str = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -53303,7 +46899,6 @@ class ShortcutsSection(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
 
 class ShortcutsSectionClass(_gi.Struct): ...
@@ -53518,7 +47113,9 @@ class ShortcutsShortcut(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
+        accel_size_group: SizeGroup
         accelerator: str
         action_name: str
         direction: TextDirection
@@ -53528,54 +47125,8 @@ class ShortcutsShortcut(Box):
         subtitle: str
         subtitle_set: bool
         title: str
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        orientation: Orientation
-        accel_size_group: SizeGroup
         title_size_group: SizeGroup
-        child: Widget
+        orientation: Orientation
 
     @property
     def props(self) -> Props: ...
@@ -53593,6 +47144,7 @@ class ShortcutsShortcut(Box):
         subtitle_set: bool = ...,
         title: str = ...,
         title_size_group: SizeGroup = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -53635,7 +47187,6 @@ class ShortcutsShortcut(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
 
 class ShortcutsShortcutClass(_gi.Struct): ...
@@ -53903,84 +47454,10 @@ class ShortcutsWindow(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         section_name: str
         view_name: str
-        accept_focus: bool
-        application: Application | None
-        attached_to: Widget | None
-        decorated: bool
-        default_height: int
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        focus_on_map: bool
-        focus_visible: bool
-        gravity: _Gdk3.Gravity
-        has_resize_grip: bool
-        has_toplevel_focus: bool
-        hide_titlebar_when_maximized: bool
-        icon: GdkPixbuf.Pixbuf | None
-        icon_name: str | None
-        is_active: bool
-        is_maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        resize_grip_visible: bool
-        role: str | None
-        screen: _Gdk3.Screen
-        skip_pager_hint: bool
-        skip_taskbar_hint: bool
-        title: str | None
-        transient_for: Window | None
-        type: WindowType
-        type_hint: _Gdk3.WindowTypeHint
-        urgency_hint: bool
-        window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -54098,6 +47575,7 @@ class SizeGroup(GObject.Object, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         ignore_hidden: bool
         mode: SizeGroupMode
@@ -54317,52 +47795,6 @@ class Socket(Container):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Container.Props):
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
-
-    @property
-    def props(self) -> Props: ...
     @property
     def container(self) -> Container: ...
     @property
@@ -54491,28 +47923,6 @@ class SocketAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -54898,6 +48308,7 @@ class SpinButton(Entry, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Entry.Props):
         adjustment: Adjustment
         climb_rate: float
@@ -54907,96 +48318,6 @@ class SpinButton(Entry, Orientable):
         update_policy: SpinButtonUpdatePolicy
         value: float
         wrap: bool
-        activates_default: bool
-        attributes: Pango.AttrList | None
-        buffer: EntryBuffer
-        caps_lock_warning: bool
-        completion: EntryCompletion
-        cursor_position: int
-        editable: bool
-        enable_emoji_completion: bool
-        has_frame: bool
-        im_module: str
-        inner_border: Border | None
-        input_hints: InputHints
-        input_purpose: InputPurpose
-        invisible_char: int
-        invisible_char_set: bool
-        max_length: int
-        max_width_chars: int
-        overwrite_mode: bool
-        placeholder_text: str
-        populate_all: bool
-        primary_icon_activatable: bool
-        primary_icon_gicon: Gio.Icon
-        primary_icon_name: str
-        primary_icon_pixbuf: GdkPixbuf.Pixbuf
-        primary_icon_sensitive: bool
-        primary_icon_stock: str
-        primary_icon_storage_type: ImageType
-        primary_icon_tooltip_markup: str
-        primary_icon_tooltip_text: str
-        progress_fraction: float
-        progress_pulse_step: float
-        scroll_offset: int
-        secondary_icon_activatable: bool
-        secondary_icon_gicon: Gio.Icon
-        secondary_icon_name: str
-        secondary_icon_pixbuf: GdkPixbuf.Pixbuf
-        secondary_icon_sensitive: bool
-        secondary_icon_stock: str
-        secondary_icon_storage_type: ImageType
-        secondary_icon_tooltip_markup: str
-        secondary_icon_tooltip_text: str
-        selection_bound: int
-        shadow_type: ShadowType
-        show_emoji_icon: bool
-        tabs: Pango.TabArray | None
-        text: str
-        text_length: int
-        truncate_multiline: bool
-        visibility: bool
-        width_chars: int
-        xalign: float
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         editing_canceled: bool
         orientation: Orientation
 
@@ -55017,6 +48338,8 @@ class SpinButton(Entry, Orientable):
         update_policy: SpinButtonUpdatePolicy = ...,
         value: float = ...,
         wrap: bool = ...,
+        editing_canceled: bool = ...,
+        orientation: Orientation = ...,
         activates_default: bool = ...,
         attributes: Pango.AttrList = ...,
         buffer: EntryBuffer = ...,
@@ -55098,8 +48421,6 @@ class SpinButton(Entry, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        editing_canceled: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def configure(
         self, adjustment: Adjustment | None, climb_rate: float, digits: int
@@ -55229,28 +48550,6 @@ class SpinButtonAccessible(EntryAccessible, Atk.Value):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EntryAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> EntryAccessible: ...
     @property
@@ -55480,47 +48779,9 @@ class Spinner(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         active: bool
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
 
     @property
     def props(self) -> Props: ...
@@ -55644,28 +48905,6 @@ class SpinnerAccessible(WidgetAccessible, Atk.Image):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -55915,58 +49154,18 @@ class Stack(Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         hhomogeneous: bool
         homogeneous: bool
         interpolate_size: bool
         transition_duration: int
-        transition_running: bool
+        @property
+        def transition_running(self) -> bool: ...
         transition_type: StackTransitionType
         vhomogeneous: bool
         visible_child: Widget | None
         visible_child_name: str | None
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -56122,28 +49321,6 @@ class StackAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     def __init__(
@@ -56371,50 +49548,9 @@ class StackSidebar(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         stack: Stack | None
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -56675,55 +49811,11 @@ class StackSwitcher(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         icon_size: int
         stack: Stack | None
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -56734,6 +49826,7 @@ class StackSwitcher(Box):
         *,
         icon_size: int = ...,
         stack: Stack | None = ...,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -56776,7 +49869,6 @@ class StackSwitcher(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_stack(self) -> Stack | None: ...
     @classmethod
@@ -56854,22 +49946,27 @@ class StatusIcon(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        embedded: bool
+        @property
+        def embedded(self) -> bool: ...
+        file: str
         gicon: Gio.Icon | None
         has_tooltip: bool
         icon_name: str | None
-        orientation: Orientation
+        @property
+        def orientation(self) -> Orientation: ...
         pixbuf: GdkPixbuf.Pixbuf | None
         screen: _Gdk3.Screen
-        size: int
+        @property
+        def size(self) -> int: ...
         stock: str | None
-        storage_type: ImageType
+        @property
+        def storage_type(self) -> ImageType: ...
         title: str
         tooltip_markup: str | None
         tooltip_text: str | None
         visible: bool
-        file: str
 
     @property
     def props(self) -> Props: ...
@@ -57167,53 +50264,9 @@ class Statusbar(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -57224,6 +50277,7 @@ class Statusbar(Box):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -57266,7 +50320,6 @@ class Statusbar(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_text_popped(self, context_id: int, text: str) -> None: ...
     def do_text_pushed(self, context_id: int, text: str) -> None: ...
@@ -57352,28 +50405,6 @@ class StatusbarAccessible(ContainerAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -57468,8 +50499,10 @@ class Style(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        context: StyleContext
+        @property
+        def context(self) -> StyleContext: ...
 
     @property
     def props(self) -> Props: ...
@@ -58208,6 +51241,7 @@ class StyleContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         direction: TextDirection
         paint_clock: _Gdk3.FrameClock
@@ -58562,48 +51596,10 @@ class Switch(Widget, Actionable, Activatable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         active: bool
         state: bool
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
@@ -58620,6 +51616,10 @@ class Switch(Widget, Actionable, Activatable):
         *,
         active: bool = ...,
         state: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -58656,10 +51656,6 @@ class Switch(Widget, Actionable, Activatable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_activate(self) -> None: ...
     def do_state_set(self, state: bool) -> bool: ...
@@ -58740,28 +51736,6 @@ class SwitchAccessible(WidgetAccessible, Atk.Action):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(WidgetAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> WidgetAccessible: ...
     @property
@@ -58850,7 +51824,7 @@ class SymbolicColor(GObject.GBoxed):
     def to_string(self) -> str: ...
     def unref(self) -> None: ...
 
-class Table(Container, Container):
+class Table(Container):
     """
     :Constructors:
 
@@ -59041,54 +52015,13 @@ class Table(Container, Container):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         column_spacing: int
         homogeneous: bool
         n_columns: int
         n_rows: int
         row_spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -59491,58 +52424,12 @@ class TearoffMenuItem(MenuItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MenuItem.Props):
-        accel_path: str | None
-        label: str
-        right_justified: bool
-        submenu: Menu | None
-        use_underline: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -59553,6 +52440,10 @@ class TearoffMenuItem(MenuItem):
     def __init__(
         self,
         *,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         accel_path: str | None = ...,
         label: str = ...,
         right_justified: bool = ...,
@@ -59597,10 +52488,6 @@ class TearoffMenuItem(MenuItem):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> TearoffMenuItem: ...
@@ -59618,24 +52505,7 @@ class TearoffMenuItemClass(_gi.Struct):
 
 class TearoffMenuItemPrivate(_gi.Struct): ...
 
-# override
-class Template:
-    def __init__(
-        self, filename: str = ..., resource_path: str = ..., string: str = ...
-    ) -> None: ...
-    @classmethod
-    def from_file(cls, filename: str): ...
-    @classmethod
-    def from_resource(cls, resource_path: str): ...
-    @classmethod
-    def from_string(cls, string: str): ...
-    def __call__(self, cls): ...
-
-    class Callback:
-        def __init__(self, name: str = ...) -> None: ...
-        def __call__(self, func: Callable[..., Any]) -> Any: ...
-
-    class Child: ...
+Template = _gtktemplate.Template
 
 class TextAppearance(_gi.Struct):
     """
@@ -59743,12 +52613,18 @@ class TextBuffer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        copy_target_list: TargetList
-        cursor_position: int
-        has_selection: bool
-        paste_target_list: TargetList
-        tag_table: TextTagTable
+        @property
+        def copy_target_list(self) -> TargetList: ...
+        @property
+        def cursor_position(self) -> int: ...
+        @property
+        def has_selection(self) -> bool: ...
+        @property
+        def paste_target_list(self) -> TargetList: ...
+        @property
+        def tag_table(self) -> TextTagTable: ...
         text: str
 
     @property
@@ -60039,29 +52915,6 @@ class TextCellAccessible(RendererCellAccessible, Atk.Text):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(RendererCellAccessible.Props):
-        renderer: CellRenderer
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> RendererCellAccessible: ...
     @property
@@ -60291,9 +53144,12 @@ class TextMark(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        left_gravity: bool
-        name: str | None
+        @property
+        def left_gravity(self) -> bool: ...
+        @property
+        def name(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -60489,8 +53345,10 @@ class TextTag(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accumulative_margin: bool
+        background: str
         background_full_height: bool
         background_full_height_set: bool
         background_gdk: _Gdk3.Color
@@ -60507,6 +53365,7 @@ class TextTag(GObject.Object):
         font_desc: Pango.FontDescription
         font_features: str
         font_features_set: bool
+        foreground: str
         foreground_gdk: _Gdk3.Color
         foreground_rgba: _Gdk3.RGBA
         foreground_set: bool
@@ -60522,7 +53381,9 @@ class TextTag(GObject.Object):
         left_margin_set: bool
         letter_spacing: int
         letter_spacing_set: bool
-        name: str
+        @property
+        def name(self) -> str: ...
+        paragraph_background: str
         paragraph_background_gdk: _Gdk3.Color
         paragraph_background_rgba: _Gdk3.RGBA
         paragraph_background_set: bool
@@ -60561,9 +53422,6 @@ class TextTag(GObject.Object):
         weight_set: bool
         wrap_mode: WrapMode
         wrap_mode_set: bool
-        background: str
-        foreground: str
-        paragraph_background: str
 
     @property
     def props(self) -> Props: ...
@@ -60973,10 +53831,11 @@ class TextView(Container, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         accepts_tab: bool
         bottom_margin: int
-        buffer: TextBuffer
+        buffer: TextBuffer | None
         cursor_visible: bool
         editable: bool
         im_module: str
@@ -60995,52 +53854,10 @@ class TextView(Container, Scrollable):
         tabs: Pango.TabArray | None
         top_margin: int
         wrap_mode: WrapMode
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscroll_policy: ScrollablePolicy
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -61072,6 +53889,10 @@ class TextView(Container, Scrollable):
         tabs: Pango.TabArray = ...,
         top_margin: int = ...,
         wrap_mode: WrapMode = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -61111,10 +53932,6 @@ class TextView(Container, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def add_child_at_anchor(self, child: Widget, anchor: TextChildAnchor) -> None: ...
     def add_child_in_window(
@@ -61320,28 +54137,6 @@ class TextViewAccessible(
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -61444,8 +54239,10 @@ class ThemingEngine(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        name: str
+        @property
+        def name(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -61804,25 +54601,10 @@ class ToggleAction(Action):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Action.Props):
         active: bool
         draw_as_radio: bool
-        action_group: ActionGroup
-        always_show_image: bool
-        gicon: Gio.Icon
-        hide_if_empty: bool
-        icon_name: str
-        is_important: bool
-        label: str
-        name: str
-        sensitive: bool
-        short_label: str
-        stock_id: str
-        tooltip: str
-        visible: bool
-        visible_horizontal: bool
-        visible_overflown: bool
-        visible_vertical: bool
 
     @property
     def props(self) -> Props: ...
@@ -62119,65 +54901,15 @@ class ToggleButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         active: bool
         draw_indicator: bool
         inconsistent: bool
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -62191,6 +54923,10 @@ class ToggleButton(Button):
         active: bool = ...,
         draw_indicator: bool = ...,
         inconsistent: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         always_show_image: bool = ...,
         image: Widget | None = ...,
         image_position: PositionType = ...,
@@ -62239,10 +54975,6 @@ class ToggleButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_toggled(self) -> None: ...
     def get_active(self) -> bool: ...
@@ -62335,28 +55067,6 @@ class ToggleButtonAccessible(ButtonAccessible):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ButtonAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ButtonAccessible: ...
     @property
@@ -62625,63 +55335,13 @@ class ToggleToolButton(ToolButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToolButton.Props):
         active: bool
-        icon_name: str | None
-        icon_widget: Widget | None
-        label: str | None
-        label_widget: Widget | None
-        stock_id: str
-        use_underline: bool
-        is_important: bool
-        visible_horizontal: bool
-        visible_vertical: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -62693,6 +55353,10 @@ class ToggleToolButton(ToolButton):
         self,
         *,
         active: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         icon_name: str | None = ...,
         icon_widget: Widget | None = ...,
         label: str | None = ...,
@@ -62741,10 +55405,6 @@ class ToggleToolButton(ToolButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_toggled(self) -> None: ...
     def get_active(self) -> bool: ...
@@ -62978,62 +55638,18 @@ class ToolButton(ToolItem, Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ToolItem.Props):
         icon_name: str | None
         icon_widget: Widget | None
         label: str | None
         label_widget: Widget | None
-        stock_id: str
+        stock_id: str | None
         use_underline: bool
-        is_important: bool
-        visible_horizontal: bool
-        visible_vertical: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -63050,6 +55666,10 @@ class ToolButton(ToolItem, Actionable):
         label_widget: Widget | None = ...,
         stock_id: str | None = ...,
         use_underline: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         is_important: bool = ...,
         visible_horizontal: bool = ...,
         visible_vertical: bool = ...,
@@ -63092,10 +55712,6 @@ class ToolButton(ToolItem, Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_clicked(self) -> None: ...
     def get_icon_name(self) -> str | None: ...
@@ -63325,54 +55941,13 @@ class ToolItem(Bin, Activatable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         is_important: bool
         visible_horizontal: bool
         visible_vertical: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         related_action: Action
         use_action_appearance: bool
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -63386,6 +55961,8 @@ class ToolItem(Bin, Activatable):
         is_important: bool = ...,
         visible_horizontal: bool = ...,
         visible_vertical: bool = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -63425,8 +56002,6 @@ class ToolItem(Bin, Activatable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
     ) -> None: ...
     def do_create_menu_proxy(self) -> bool: ...
     def do_toolbar_reconfigured(self) -> None: ...
@@ -63668,54 +56243,13 @@ class ToolItemGroup(Container, ToolShell):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         collapsed: bool
         ellipsize: Pango.EllipsizeMode
         header_relief: ReliefStyle
         label: str
         label_widget: Widget
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -63991,57 +56525,16 @@ class ToolPalette(Container, Orientable, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         icon_size: IconSize
         icon_size_set: bool
         toolbar_style: ToolbarStyle
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscroll_policy: ScrollablePolicy
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -64055,6 +56548,11 @@ class ToolPalette(Container, Orientable, Scrollable):
         icon_size: IconSize = ...,
         icon_size_set: bool = ...,
         toolbar_style: ToolbarStyle = ...,
+        orientation: Orientation = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -64094,11 +56592,6 @@ class ToolPalette(Container, Orientable, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def add_drag_dest(
         self,
@@ -64386,54 +56879,13 @@ class Toolbar(Container, Orientable, ToolShell):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Container.Props):
         icon_size: IconSize
         icon_size_set: bool
         show_arrow: bool
         toolbar_style: ToolbarStyle
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -64448,6 +56900,7 @@ class Toolbar(Container, Orientable, ToolShell):
         icon_size_set: bool = ...,
         show_arrow: bool = ...,
         toolbar_style: ToolbarStyle = ...,
+        orientation: Orientation = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -64487,7 +56940,6 @@ class Toolbar(Container, Orientable, ToolShell):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_orientation_changed(self, orientation: Orientation) -> None: ...
     def do_popup_context_menu(self, x: int, y: int, button_number: int) -> bool: ...
@@ -64615,27 +57067,6 @@ class ToplevelAccessible(Atk.Object):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Atk.Object.Props):
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Atk.Object: ...
     @property
@@ -64816,9 +57247,12 @@ class TreeModelFilter(GObject.Object, TreeDragSource, TreeModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child_model: TreeModel
-        virtual_root: TreePath
+        @property
+        def child_model(self) -> TreeModel: ...
+        @property
+        def virtual_root(self) -> TreePath: ...
 
     @property
     def props(self) -> Props: ...
@@ -64983,8 +57417,10 @@ class TreeModelSort(GObject.Object, TreeDragSource, TreeModel, TreeSortable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        model: TreeModel
+        @property
+        def model(self) -> TreeModel: ...
 
     @property
     def props(self) -> Props: ...
@@ -65107,6 +57543,7 @@ class TreeSelection(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         mode: SelectionMode
 
@@ -65207,14 +57644,7 @@ class TreeSortableIface(_gi.Struct):
     def has_default_sort_func(self) -> Callable[[TreeSortable], bool]: ...
 
 class TreeStore(
-    GObject.Object,
-    Buildable,
-    TreeDragDest,
-    TreeDragSource,
-    TreeModel,
-    TreeSortable,
-    TreeModel,
-    TreeSortable,
+    GObject.Object, Buildable, TreeDragDest, TreeDragSource, TreeModel, TreeSortable
 ):
     """
     :Constructors:
@@ -65949,28 +58379,6 @@ class TreeViewAccessible(
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property
@@ -66109,9 +58517,11 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         alignment: float
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         clickable: bool
         expand: bool
         fixed_width: int
@@ -66127,8 +58537,10 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
         title: str
         visible: bool
         widget: Widget | None
-        width: int
-        x_offset: int
+        @property
+        def width(self) -> int: ...
+        @property
+        def x_offset(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -66263,9 +58675,11 @@ class UIManager(GObject.Object, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         add_tearoffs: bool
-        ui: str
+        @property
+        def ui(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -66530,53 +58944,9 @@ class VBox(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -66585,6 +58955,7 @@ class VBox(Box):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
@@ -66627,7 +58998,6 @@ class VBox(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, homogeneous: bool, spacing: int) -> VBox: ...
@@ -66834,54 +59204,9 @@ class VButtonBox(ButtonBox):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ButtonBox.Props):
-        layout_style: ButtonBoxStyle
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -66890,6 +59215,7 @@ class VButtonBox(ButtonBox):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         layout_style: ButtonBoxStyle = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
@@ -66933,7 +59259,6 @@ class VButtonBox(ButtonBox):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> VButtonBox: ...
@@ -67148,55 +59473,9 @@ class VPaned(Paned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Paned.Props):
-        max_position: int
-        min_position: int
-        position: int
-        position_set: bool
-        wide_handle: bool
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -67205,6 +59484,7 @@ class VPaned(Paned):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         position: int = ...,
         position_set: bool = ...,
         wide_handle: bool = ...,
@@ -67247,7 +59527,6 @@ class VPaned(Paned):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> VPaned: ...
@@ -67466,58 +59745,8 @@ class VScale(Scale):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Scale.Props):
-        digits: int
-        draw_value: bool
-        has_origin: bool
-        value_pos: PositionType
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        lower_stepper_sensitivity: SensitivityType
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -67527,6 +59756,7 @@ class VScale(Scale):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         digits: int = ...,
         draw_value: bool = ...,
         has_origin: bool = ...,
@@ -67575,7 +59805,6 @@ class VScale(Scale):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, adjustment: Adjustment) -> VScale: ...
@@ -67782,54 +60011,8 @@ class VScrollbar(Scrollbar):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Scrollbar.Props):
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        lower_stepper_sensitivity: SensitivityType
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        upper_stepper_sensitivity: SensitivityType
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -67839,6 +60022,7 @@ class VScrollbar(Scrollbar):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         fill_level: float = ...,
         inverted: bool = ...,
@@ -67883,7 +60067,6 @@ class VScrollbar(Scrollbar):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, adjustment: Adjustment | None = None) -> VScrollbar: ...
@@ -68064,46 +60247,8 @@ class VSeparator(Separator):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Separator.Props):
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         orientation: Orientation
 
     @property
@@ -68113,6 +60258,7 @@ class VSeparator(Separator):
     def __init__(
         self,
         *,
+        orientation: Orientation = ...,
         app_paintable: bool = ...,
         can_default: bool = ...,
         can_focus: bool = ...,
@@ -68149,7 +60295,6 @@ class VSeparator(Separator):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> VSeparator: ...
@@ -68348,54 +60493,13 @@ class Viewport(Bin, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         shadow_type: ShadowType
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscroll_policy: ScrollablePolicy
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -68407,6 +60511,10 @@ class Viewport(Bin, Scrollable):
         self,
         *,
         shadow_type: ShadowType = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         border_width: int = ...,
         child: Widget = ...,
         resize_mode: ResizeMode = ...,
@@ -68446,10 +60554,6 @@ class Viewport(Bin, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def get_bin_window(self) -> _Gdk3.Window: ...
     def get_hadjustment(self) -> Adjustment: ...
@@ -68705,68 +60809,14 @@ class VolumeButton(ScaleButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ScaleButton.Props):
         use_symbolic: bool
-        adjustment: Adjustment
-        icons: list[str]
-        size: IconSize
-        value: float
-        always_show_image: bool
-        image: Widget | None
-        image_position: PositionType
-        label: str
-        relief: ReliefStyle
-        use_stock: bool
-        use_underline: bool
-        xalign: float
-        yalign: float
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
         action_name: str | None
         action_target: GLib.Variant
         related_action: Action
         use_action_appearance: bool
         orientation: Orientation
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -68776,6 +60826,11 @@ class VolumeButton(ScaleButton):
         self,
         *,
         use_symbolic: bool = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
+        related_action: Action = ...,
+        use_action_appearance: bool = ...,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         icons: Sequence[str] = ...,
         size: IconSize = ...,
@@ -68828,11 +60883,6 @@ class VolumeButton(ScaleButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
-        related_action: Action = ...,
-        use_action_appearance: bool = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> VolumeButton: ...
@@ -69012,11 +61062,13 @@ class Widget(GObject.InitiallyUnowned, Atk.ImplementorIface, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         app_paintable: bool
         can_default: bool
         can_focus: bool
-        composite_child: bool
+        @property
+        def composite_child(self) -> bool: ...
         double_buffered: bool
         events: _Gdk3.EventMask
         expand: bool
@@ -69041,9 +61093,10 @@ class Widget(GObject.InitiallyUnowned, Atk.ImplementorIface, Buildable):
         opacity: float
         parent: Container | None
         receives_default: bool
-        scale_factor: int
+        @property
+        def scale_factor(self) -> int: ...
         sensitive: bool
-        style: Style
+        style: Style | None
         tooltip_markup: str | None
         tooltip_text: str | None
         valign: Align
@@ -69051,7 +61104,8 @@ class Widget(GObject.InitiallyUnowned, Atk.ImplementorIface, Buildable):
         vexpand_set: bool
         visible: bool
         width_request: int
-        window: _Gdk3.Window | None
+        @property
+        def window(self) -> _Gdk3.Window | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -69668,28 +61722,6 @@ class WidgetAccessible(Accessible, Atk.Component):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Accessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> Accessible: ...
     @property
@@ -70270,6 +62302,7 @@ class Window(Bin):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Bin.Props):
         accept_focus: bool
         application: Application | None
@@ -70283,69 +62316,32 @@ class Window(Bin):
         focus_visible: bool
         gravity: _Gdk3.Gravity
         has_resize_grip: bool
-        has_toplevel_focus: bool
+        @property
+        def has_toplevel_focus(self) -> bool: ...
         hide_titlebar_when_maximized: bool
         icon: GdkPixbuf.Pixbuf | None
         icon_name: str | None
-        is_active: bool
-        is_maximized: bool
+        @property
+        def is_active(self) -> bool: ...
+        @property
+        def is_maximized(self) -> bool: ...
         mnemonics_visible: bool
         modal: bool
         resizable: bool
-        resize_grip_visible: bool
+        @property
+        def resize_grip_visible(self) -> bool: ...
         role: str | None
         screen: _Gdk3.Screen
         skip_pager_hint: bool
         skip_taskbar_hint: bool
+        startup_id: str
         title: str | None
         transient_for: Window | None
-        type: WindowType
+        @property
+        def type(self) -> WindowType: ...
         type_hint: _Gdk3.WindowTypeHint
         urgency_hint: bool
         window_position: WindowPosition
-        border_width: int
-        resize_mode: ResizeMode
-        app_paintable: bool
-        can_default: bool
-        can_focus: bool
-        composite_child: bool
-        double_buffered: bool
-        events: _Gdk3.EventMask
-        expand: bool
-        focus_on_click: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        is_focus: bool
-        margin: int
-        margin_bottom: int
-        margin_end: int
-        margin_left: int
-        margin_right: int
-        margin_start: int
-        margin_top: int
-        name: str
-        no_show_all: bool
-        opacity: float
-        parent: Container | None
-        receives_default: bool
-        scale_factor: int
-        sensitive: bool
-        style: Style
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        window: _Gdk3.Window | None
-        startup_id: str
-        child: Widget
 
     @property
     def props(self) -> Props: ...
@@ -70658,28 +62654,6 @@ class WindowAccessible(ContainerAccessible, Atk.Window):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(ContainerAccessible.Props):
-        widget: Widget | None
-        accessible_component_layer: int
-        accessible_component_mdi_zorder: int
-        accessible_description: str
-        accessible_help_text: str
-        accessible_hypertext_nlinks: int
-        accessible_id: str
-        accessible_name: str
-        accessible_parent: Atk.Object
-        accessible_role: Atk.Role
-        accessible_table_caption: str
-        accessible_table_caption_object: Atk.Object
-        accessible_table_column_description: str
-        accessible_table_column_header: Atk.Object
-        accessible_table_row_description: str
-        accessible_table_row_header: Atk.Object
-        accessible_table_summary: Atk.Object
-        accessible_value: float
-
-    @property
-    def props(self) -> Props: ...
     @property
     def parent(self) -> ContainerAccessible: ...
     @property

--- a/src/gi-stubs/repository/_Gtk4.pyi
+++ b/src/gi-stubs/repository/_Gtk4.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import type_check_only
 from typing import TypeVar
 from typing_extensions import Self
 
@@ -384,8 +385,10 @@ class ATContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        accessible: Accessible
+        @property
+        def accessible(self) -> Accessible: ...
         accessible_role: AccessibleRole
         display: _Gdk4.Display
 
@@ -532,6 +535,7 @@ class AboutDialog(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         artists: list[str]
         authors: list[str]
@@ -549,68 +553,7 @@ class AboutDialog(Window):
         website: str | None
         website_label: str | None
         wrap_license: bool
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -633,6 +576,7 @@ class AboutDialog(Window):
         website: str | None = ...,
         website_label: str = ...,
         wrap_license: bool = ...,
+        accessible_role: AccessibleRole = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
         decorated: bool = ...,
@@ -687,7 +631,6 @@ class AboutDialog(Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_credit_section(self, section_name: str, people: Sequence[str]) -> None: ...
     def get_artists(self) -> list[str]: ...
@@ -806,7 +749,13 @@ class AccessibleList(GObject.GBoxed):
     @classmethod
     def new_from_list(cls, list: list[Accessible]) -> AccessibleList: ...
 
-class AccessibleRange(GObject.GInterface, Protocol): ...
+class AccessibleRange(GObject.GInterface, Protocol):
+    """
+    Interface GtkAccessibleRange
+
+    Signals from GObject:
+      notify (GParam)
+    """
 
 class AccessibleRangeInterface(_gi.Struct):
     """
@@ -959,43 +908,9 @@ class ActionBar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         revealed: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -1004,6 +919,7 @@ class ActionBar(Widget):
         self,
         *,
         revealed: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -1034,7 +950,6 @@ class ActionBar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_center_widget(self) -> Widget | None: ...
     def get_revealed(self) -> bool: ...
@@ -1128,6 +1043,7 @@ class Adjustment(GObject.InitiallyUnowned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         lower: float
         page_increment: float
@@ -1222,6 +1138,7 @@ class AlertDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         buttons: list[str] | None
         cancel_button: int
@@ -1293,9 +1210,12 @@ class AlternativeTrigger(ShortcutTrigger):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ShortcutTrigger.Props):
-        first: ShortcutTrigger
-        second: ShortcutTrigger
+        @property
+        def first(self) -> ShortcutTrigger: ...
+        @property
+        def second(self) -> ShortcutTrigger: ...
 
     @property
     def props(self) -> Props: ...
@@ -1338,12 +1258,6 @@ class AnyFilter(MultiFilter):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(MultiFilter.Props):
-        item_type: type[Any]
-        n_items: int
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> AnyFilter: ...
 
@@ -1437,48 +1351,15 @@ class AppChooserButton(Widget, AppChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         heading: str | None
         modal: bool
         show_default_item: bool
         show_dialog_item: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        content_type: str
+        @property
+        def content_type(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -1489,6 +1370,8 @@ class AppChooserButton(Widget, AppChooser):
         modal: bool = ...,
         show_default_item: bool = ...,
         show_dialog_item: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        content_type: str = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -1519,8 +1402,6 @@ class AppChooserButton(Widget, AppChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        content_type: str = ...,
     ) -> None: ...
     def append_custom_item(self, name: str, label: str, icon: Gio.Icon) -> None: ...
     def append_separator(self) -> None: ...
@@ -1649,73 +1530,14 @@ class AppChooserDialog(Dialog, AppChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        gfile: Gio.File
+        @property
+        def gfile(self) -> Gio.File: ...
         heading: str | None
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        content_type: str
-        startup_id: str
+        @property
+        def content_type(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -1724,6 +1546,8 @@ class AppChooserDialog(Dialog, AppChooser):
         *,
         gfile: Gio.File = ...,
         heading: str = ...,
+        accessible_role: AccessibleRole = ...,
+        content_type: str = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -1779,8 +1603,6 @@ class AppChooserDialog(Dialog, AppChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        content_type: str = ...,
     ) -> None: ...
     def get_heading(self) -> str | None: ...
     def get_widget(self) -> Widget: ...
@@ -1872,6 +1694,7 @@ class AppChooserWidget(Widget, AppChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         default_text: str | None
         show_all: bool
@@ -1879,43 +1702,9 @@ class AppChooserWidget(Widget, AppChooser):
         show_fallback: bool
         show_other: bool
         show_recommended: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        content_type: str
+        @property
+        def content_type(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -1928,6 +1717,8 @@ class AppChooserWidget(Widget, AppChooser):
         show_fallback: bool = ...,
         show_other: bool = ...,
         show_recommended: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        content_type: str = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -1958,8 +1749,6 @@ class AppChooserWidget(Widget, AppChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        content_type: str = ...,
     ) -> None: ...
     def get_default_text(self) -> str | None: ...
     def get_show_all(self) -> bool: ...
@@ -2033,20 +1822,14 @@ class Application(Gio.Application):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.Application.Props):
-        active_window: Window | None
+        @property
+        def active_window(self) -> Window | None: ...
         menubar: Gio.MenuModel | None
         register_session: bool
-        screensaver_active: bool
-        application_id: str | None
-        flags: Gio.ApplicationFlags
-        inactivity_timeout: int
-        is_busy: bool
-        is_registered: bool
-        is_remote: bool
-        resource_base_path: str | None
-        version: str | None
-        action_group: Gio.ActionGroup | None
+        @property
+        def screensaver_active(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -2219,70 +2002,10 @@ class ApplicationWindow(Window, Gio.ActionGroup, Gio.ActionMap):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         show_menubar: bool
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -2292,6 +2015,7 @@ class ApplicationWindow(Window, Gio.ActionGroup, Gio.ActionMap):
         self,
         *,
         show_menubar: bool = ...,
+        accessible_role: AccessibleRole = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
         decorated: bool = ...,
@@ -2346,7 +2070,6 @@ class ApplicationWindow(Window, Gio.ActionGroup, Gio.ActionMap):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_help_overlay(self) -> ShortcutsWindow | None: ...
     def get_id(self) -> int: ...
@@ -2442,47 +2165,13 @@ class AspectFrame(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
         obey_child: bool
         ratio: float
         xalign: float
         yalign: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -2495,6 +2184,7 @@ class AspectFrame(Widget):
         ratio: float = ...,
         xalign: float = ...,
         yalign: float = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -2525,7 +2215,6 @@ class AspectFrame(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     def get_obey_child(self) -> bool: ...
@@ -2654,71 +2343,13 @@ class Assistant(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
-        pages: Gio.ListModel
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def pages(self) -> Gio.ListModel: ...
+        @property
+        def use_header_bar(self) -> int: ...
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -2726,6 +2357,7 @@ class Assistant(Window):
         self,
         *,
         use_header_bar: int = ...,
+        accessible_role: AccessibleRole = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
         decorated: bool = ...,
@@ -2780,7 +2412,6 @@ class Assistant(Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_action_widget(self, child: Widget) -> None: ...
     def append_page(self, page: Widget) -> int: ...
@@ -2829,8 +2460,10 @@ class AssistantPage(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child: Widget
+        @property
+        def child(self) -> Widget: ...
         complete: bool
         page_type: AssistantPageType
         title: str
@@ -2966,13 +2599,18 @@ class BookmarkList(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         attributes: str | None
-        filename: str
+        @property
+        def filename(self) -> str: ...
         io_priority: int
-        item_type: type[Any]
-        loading: bool
-        n_items: int
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def loading(self) -> bool: ...
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -3026,6 +2664,7 @@ class BoolFilter(Filter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Filter.Props):
         expression: Expression | None
         invert: bool
@@ -3146,46 +2785,12 @@ class Box(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         baseline_child: int
         baseline_position: BaselinePosition
         homogeneous: bool
         spacing: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -3200,6 +2805,8 @@ class Box(Widget, Orientable):
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
         spacing: int = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -3230,8 +2837,6 @@ class Box(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def append(self, child: Widget) -> None: ...
     def get_baseline_child(self) -> int: ...
@@ -3286,6 +2891,7 @@ class BoxLayout(LayoutManager, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(LayoutManager.Props):
         baseline_child: int
         baseline_position: BaselinePosition
@@ -3429,9 +3035,10 @@ class Builder(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         current_object: GObject.Object | None
-        scope: BuilderScope
+        scope: BuilderScope | None
         translation_domain: str | None
 
     @property
@@ -3545,10 +3152,14 @@ class BuilderListItemFactory(ListItemFactory):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ListItemFactory.Props):
-        bytes: GLib.Bytes
-        resource: str | None
-        scope: BuilderScope | None
+        @property
+        def bytes(self) -> GLib.Bytes: ...
+        @property
+        def resource(self) -> str | None: ...
+        @property
+        def scope(self) -> BuilderScope | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -3568,7 +3179,14 @@ class BuilderListItemFactory(ListItemFactory):
     ) -> BuilderListItemFactory: ...
 
 class BuilderListItemFactoryClass(_gi.Struct): ...
-class BuilderScope(GObject.GInterface, Protocol): ...
+
+class BuilderScope(GObject.GInterface, Protocol):
+    """
+    Interface GtkBuilderScope
+
+    Signals from GObject:
+      notify (GParam)
+    """
 
 class BuilderScopeInterface(_gi.Struct):
     """
@@ -3677,6 +3295,7 @@ class Button(Widget, Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         can_shrink: bool
         child: Widget | None
@@ -3684,41 +3303,6 @@ class Button(Widget, Actionable):
         icon_name: str | None
         label: str | None
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -3736,6 +3320,9 @@ class Button(Widget, Actionable):
         icon_name: str = ...,
         label: str = ...,
         use_underline: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -3766,9 +3353,6 @@ class Button(Widget, Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def do_activate(self) -> None: ...
     def do_clicked(self) -> None: ...
@@ -3916,6 +3500,7 @@ class Calendar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         date: GLib.DateTime
         day: int
@@ -3924,41 +3509,6 @@ class Calendar(Widget):
         show_heading: bool
         show_week_numbers: bool
         year: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -3973,6 +3523,7 @@ class Calendar(Widget):
         show_heading: bool = ...,
         show_week_numbers: bool = ...,
         year: int = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -4003,7 +3554,6 @@ class Calendar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def clear_marks(self) -> None: ...
     def get_date(self) -> GLib.DateTime: ...
@@ -4070,9 +3620,12 @@ class CellArea(GObject.InitiallyUnowned, Buildable, CellLayout):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
-        edit_widget: CellEditable | None
-        edited_cell: CellRenderer | None
+        @property
+        def edit_widget(self) -> CellEditable | None: ...
+        @property
+        def edited_cell(self) -> CellRenderer | None: ...
         focus_cell: CellRenderer | None
 
     @property
@@ -4319,11 +3872,9 @@ class CellAreaBox(CellArea, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellArea.Props):
         spacing: int
-        edit_widget: CellEditable | None
-        edited_cell: CellRenderer | None
-        focus_cell: CellRenderer | None
         orientation: Orientation
 
     @property
@@ -4332,8 +3883,8 @@ class CellAreaBox(CellArea, Orientable):
         self,
         *,
         spacing: int = ...,
-        focus_cell: CellRenderer | None = ...,
         orientation: Orientation = ...,
+        focus_cell: CellRenderer | None = ...,
     ) -> None: ...
     def get_spacing(self) -> int: ...
     @classmethod
@@ -4469,12 +4020,18 @@ class CellAreaContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        area: CellArea
-        minimum_height: int
-        minimum_width: int
-        natural_height: int
-        natural_width: int
+        @property
+        def area(self) -> CellArea: ...
+        @property
+        def minimum_height(self) -> int: ...
+        @property
+        def minimum_width(self) -> int: ...
+        @property
+        def natural_height(self) -> int: ...
+        @property
+        def natural_width(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -4640,10 +4197,13 @@ class CellRenderer(GObject.InitiallyUnowned):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
+        cell_background: str
         cell_background_rgba: _Gdk4.RGBA
         cell_background_set: bool
-        editing: bool
+        @property
+        def editing(self) -> bool: ...
         height: int
         is_expanded: bool
         is_expander: bool
@@ -4655,7 +4215,6 @@ class CellRenderer(GObject.InitiallyUnowned):
         xpad: int
         yalign: float
         ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -4876,72 +4435,12 @@ class CellRendererAccel(CellRendererText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRendererText.Props):
         accel_key: int
         accel_mode: CellRendererAccelMode
         accel_mods: _Gdk4.ModifierType
         keycode: int
-        align_set: bool
-        alignment: Pango.Alignment
-        attributes: Pango.AttrList
-        background_rgba: _Gdk4.RGBA
-        background_set: bool
-        editable: bool
-        editable_set: bool
-        ellipsize: Pango.EllipsizeMode
-        ellipsize_set: bool
-        family: str
-        family_set: bool
-        font: str
-        font_desc: Pango.FontDescription
-        foreground_rgba: _Gdk4.RGBA
-        foreground_set: bool
-        language: str
-        language_set: bool
-        max_width_chars: int
-        placeholder_text: str
-        rise: int
-        rise_set: bool
-        scale: float
-        scale_set: bool
-        single_paragraph_mode: bool
-        size: int
-        size_points: float
-        size_set: bool
-        stretch: Pango.Stretch
-        stretch_set: bool
-        strikethrough: bool
-        strikethrough_set: bool
-        style: Pango.Style
-        style_set: bool
-        text: str
-        underline: Pango.Underline
-        underline_set: bool
-        variant: Pango.Variant
-        variant_set: bool
-        weight: int
-        weight_set: bool
-        width_chars: int
-        wrap_mode: Pango.WrapMode
-        wrap_width: int
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -5197,71 +4696,11 @@ class CellRendererCombo(CellRendererText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRendererText.Props):
         has_entry: bool
         model: TreeModel
         text_column: int
-        align_set: bool
-        alignment: Pango.Alignment
-        attributes: Pango.AttrList
-        background_rgba: _Gdk4.RGBA
-        background_set: bool
-        editable: bool
-        editable_set: bool
-        ellipsize: Pango.EllipsizeMode
-        ellipsize_set: bool
-        family: str
-        family_set: bool
-        font: str
-        font_desc: Pango.FontDescription
-        foreground_rgba: _Gdk4.RGBA
-        foreground_set: bool
-        language: str
-        language_set: bool
-        max_width_chars: int
-        placeholder_text: str
-        rise: int
-        rise_set: bool
-        scale: float
-        scale_set: bool
-        single_paragraph_mode: bool
-        size: int
-        size_points: float
-        size_set: bool
-        stretch: Pango.Stretch
-        stretch_set: bool
-        strikethrough: bool
-        strikethrough_set: bool
-        style: Pango.Style
-        style_set: bool
-        text: str
-        underline: Pango.Underline
-        underline_set: bool
-        variant: Pango.Variant
-        variant_set: bool
-        weight: int
-        weight_set: bool
-        width_chars: int
-        wrap_mode: Pango.WrapMode
-        wrap_width: int
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -5379,29 +4818,15 @@ class CellRendererPixbuf(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         gicon: Gio.Icon
         icon_name: str
         icon_size: IconSize
+        pixbuf: GdkPixbuf.Pixbuf
         pixbuf_expander_closed: GdkPixbuf.Pixbuf
         pixbuf_expander_open: GdkPixbuf.Pixbuf
         texture: _Gdk4.Texture
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        pixbuf: GdkPixbuf.Pixbuf
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -5478,6 +4903,7 @@ class CellRendererProgress(CellRenderer, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         inverted: bool
         pulse: int
@@ -5485,22 +4911,7 @@ class CellRendererProgress(CellRenderer, Orientable):
         text_xalign: float
         text_yalign: float
         value: int
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
         orientation: Orientation
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -5513,6 +4924,7 @@ class CellRendererProgress(CellRenderer, Orientable):
         text_xalign: float = ...,
         text_yalign: float = ...,
         value: int = ...,
+        orientation: Orientation = ...,
         cell_background: str = ...,
         cell_background_rgba: _Gdk4.RGBA = ...,
         cell_background_set: bool = ...,
@@ -5527,7 +4939,6 @@ class CellRendererProgress(CellRenderer, Orientable):
         xpad: int = ...,
         yalign: float = ...,
         ypad: int = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> CellRendererProgress: ...
@@ -5623,71 +5034,11 @@ class CellRendererSpin(CellRendererText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRendererText.Props):
         adjustment: Adjustment
         climb_rate: float
         digits: int
-        align_set: bool
-        alignment: Pango.Alignment
-        attributes: Pango.AttrList
-        background_rgba: _Gdk4.RGBA
-        background_set: bool
-        editable: bool
-        editable_set: bool
-        ellipsize: Pango.EllipsizeMode
-        ellipsize_set: bool
-        family: str
-        family_set: bool
-        font: str
-        font_desc: Pango.FontDescription
-        foreground_rgba: _Gdk4.RGBA
-        foreground_set: bool
-        language: str
-        language_set: bool
-        max_width_chars: int
-        placeholder_text: str
-        rise: int
-        rise_set: bool
-        scale: float
-        scale_set: bool
-        single_paragraph_mode: bool
-        size: int
-        size_points: float
-        size_set: bool
-        stretch: Pango.Stretch
-        stretch_set: bool
-        strikethrough: bool
-        strikethrough_set: bool
-        style: Pango.Style
-        style_set: bool
-        text: str
-        underline: Pango.Underline
-        underline_set: bool
-        variant: Pango.Variant
-        variant_set: bool
-        weight: int
-        weight_set: bool
-        width_chars: int
-        wrap_mode: Pango.WrapMode
-        wrap_width: int
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -5801,25 +5152,11 @@ class CellRendererSpinner(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         active: bool
         pulse: int
         size: IconSize
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -5933,10 +5270,12 @@ class CellRendererText(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         align_set: bool
         alignment: Pango.Alignment
         attributes: Pango.AttrList
+        background: str
         background_rgba: _Gdk4.RGBA
         background_set: bool
         editable: bool
@@ -5947,10 +5286,12 @@ class CellRendererText(CellRenderer):
         family_set: bool
         font: str
         font_desc: Pango.FontDescription
+        foreground: str
         foreground_rgba: _Gdk4.RGBA
         foreground_set: bool
         language: str
         language_set: bool
+        markup: str
         max_width_chars: int
         placeholder_text: str
         rise: int
@@ -5977,24 +5318,6 @@ class CellRendererText(CellRenderer):
         width_chars: int
         wrap_mode: Pango.WrapMode
         wrap_width: int
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        background: str
-        foreground: str
-        markup: str
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -6128,26 +5451,12 @@ class CellRendererToggle(CellRenderer):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(CellRenderer.Props):
         activatable: bool
         active: bool
         inconsistent: bool
         radio: bool
-        cell_background_rgba: _Gdk4.RGBA
-        cell_background_set: bool
-        editing: bool
-        height: int
-        is_expanded: bool
-        is_expander: bool
-        mode: CellRendererMode
-        sensitive: bool
-        visible: bool
-        width: int
-        xalign: float
-        xpad: int
-        yalign: float
-        ypad: int
-        cell_background: str
 
     @property
     def props(self) -> Props: ...
@@ -6259,47 +5568,15 @@ class CellView(Widget, CellLayout, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        cell_area: CellArea
-        cell_area_context: CellAreaContext
+        @property
+        def cell_area(self) -> CellArea: ...
+        @property
+        def cell_area_context(self) -> CellAreaContext: ...
         draw_sensitive: bool
         fit_model: bool
         model: TreeModel | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -6313,6 +5590,8 @@ class CellView(Widget, CellLayout, Orientable):
         draw_sensitive: bool = ...,
         fit_model: bool = ...,
         model: TreeModel | None = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6343,8 +5622,6 @@ class CellView(Widget, CellLayout, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_displayed_row(self) -> TreePath | None: ...
     def get_draw_sensitive(self) -> bool: ...
@@ -6438,47 +5715,13 @@ class CenterBox(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         baseline_position: BaselinePosition
         center_widget: Widget | None
         end_widget: Widget | None
         shrink_center_last: bool
         start_widget: Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -6492,6 +5735,8 @@ class CenterBox(Widget, Orientable):
         end_widget: Widget | None = ...,
         shrink_center_last: bool = ...,
         start_widget: Widget | None = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6522,8 +5767,6 @@ class CenterBox(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_baseline_position(self) -> BaselinePosition: ...
     def get_center_widget(self) -> Widget | None: ...
@@ -6557,6 +5800,7 @@ class CenterLayout(LayoutManager):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(LayoutManager.Props):
         shrink_center_last: bool
 
@@ -6669,51 +5913,17 @@ class CheckButton(Widget, Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         active: bool
         child: Widget | None
+        group: CheckButton | None
         inconsistent: bool
         label: str | None
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
-        group: CheckButton | None
 
     @property
     def props(self) -> Props: ...
@@ -6728,6 +5938,9 @@ class CheckButton(Widget, Actionable):
         inconsistent: bool = ...,
         label: str | None = ...,
         use_underline: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6758,9 +5971,6 @@ class CheckButton(Widget, Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def do_activate(self) -> None: ...
     def do_toggled(self) -> None: ...
@@ -6895,45 +6105,11 @@ class ColorButton(Widget, ColorChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         modal: bool
         show_editor: bool
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         rgba: _Gdk4.RGBA
         use_alpha: bool
@@ -6946,6 +6122,9 @@ class ColorButton(Widget, ColorChooser):
         modal: bool = ...,
         show_editor: bool = ...,
         title: str = ...,
+        accessible_role: AccessibleRole = ...,
+        rgba: _Gdk4.RGBA = ...,
+        use_alpha: bool = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -6976,9 +6155,6 @@ class ColorButton(Widget, ColorChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        rgba: _Gdk4.RGBA = ...,
-        use_alpha: bool = ...,
     ) -> None: ...
     def get_modal(self) -> bool: ...
     def get_title(self) -> str: ...
@@ -7121,73 +6297,12 @@ class ColorChooserDialog(Dialog, ColorChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         show_editor: bool
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         rgba: _Gdk4.RGBA
         use_alpha: bool
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -7195,6 +6310,9 @@ class ColorChooserDialog(Dialog, ColorChooser):
         self,
         *,
         show_editor: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        rgba: _Gdk4.RGBA = ...,
+        use_alpha: bool = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -7250,9 +6368,6 @@ class ColorChooserDialog(Dialog, ColorChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        rgba: _Gdk4.RGBA = ...,
-        use_alpha: bool = ...,
     ) -> None: ...
     @classmethod
     def new(
@@ -7356,43 +6471,9 @@ class ColorChooserWidget(Widget, ColorChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         show_editor: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         rgba: _Gdk4.RGBA
         use_alpha: bool
@@ -7403,6 +6484,9 @@ class ColorChooserWidget(Widget, ColorChooser):
         self,
         *,
         show_editor: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        rgba: _Gdk4.RGBA = ...,
+        use_alpha: bool = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -7433,9 +6517,6 @@ class ColorChooserWidget(Widget, ColorChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        rgba: _Gdk4.RGBA = ...,
-        use_alpha: bool = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> ColorChooserWidget: ...
@@ -7459,6 +6540,7 @@ class ColorDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         modal: bool
         title: str
@@ -7560,44 +6642,10 @@ class ColorDialogButton(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         dialog: ColorDialog | None
         rgba: _Gdk4.RGBA
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -7607,6 +6655,7 @@ class ColorDialogButton(Widget):
         *,
         dialog: ColorDialog = ...,
         rgba: _Gdk4.RGBA = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -7637,7 +6686,6 @@ class ColorDialogButton(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_dialog(self) -> ColorDialog | None: ...
     def get_rgba(self) -> _Gdk4.RGBA: ...
@@ -7750,8 +6798,10 @@ class ColumnView(Widget, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        columns: Gio.ListModel
+        @property
+        def columns(self) -> Gio.ListModel: ...
         enable_rubberband: bool
         header_factory: ListItemFactory | None
         model: SelectionModel | None
@@ -7760,43 +6810,9 @@ class ColumnView(Widget, Scrollable):
         show_column_separators: bool
         show_row_separators: bool
         single_click_activate: bool
-        sorter: Sorter | None
+        @property
+        def sorter(self) -> Sorter | None: ...
         tab_behavior: ListTabBehavior
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
@@ -7817,6 +6833,11 @@ class ColumnView(Widget, Scrollable):
         show_row_separators: bool = ...,
         single_click_activate: bool = ...,
         tab_behavior: ListTabBehavior = ...,
+        accessible_role: AccessibleRole = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -7847,11 +6868,6 @@ class ColumnView(Widget, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def append_column(self, column: ColumnViewColumn) -> None: ...
     def get_columns(self) -> Gio.ListModel: ...
@@ -7920,16 +6936,16 @@ class ColumnViewCell(ListItem):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ListItem.Props):
         child: Widget | None
         focusable: bool
-        item: GObject.Object | None
-        position: int
-        selected: bool
-        accessible_description: str
-        accessible_label: str
-        activatable: bool
-        selectable: bool
+        @property
+        def item(self) -> GObject.Object | None: ...
+        @property
+        def position(self) -> int: ...
+        @property
+        def selected(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -7980,8 +6996,10 @@ class ColumnViewColumn(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        column_view: ColumnView | None
+        @property
+        def column_view(self) -> ColumnView | None: ...
         expand: bool
         factory: ListItemFactory | None
         fixed_width: int
@@ -8056,15 +7074,19 @@ class ColumnViewRow(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accessible_description: str
         accessible_label: str
         activatable: bool
         focusable: bool
-        item: GObject.Object | None
-        position: int
+        @property
+        def item(self) -> GObject.Object | None: ...
+        @property
+        def position(self) -> int: ...
         selectable: bool
-        selected: bool
+        @property
+        def selected(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -8113,9 +7135,12 @@ class ColumnViewSorter(Sorter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Sorter.Props):
-        primary_sort_column: ColumnViewColumn | None
-        primary_sort_order: SortType
+        @property
+        def primary_sort_column(self) -> ColumnViewColumn | None: ...
+        @property
+        def primary_sort_order(self) -> SortType: ...
 
     @property
     def props(self) -> Props: ...
@@ -8231,53 +7256,21 @@ class ComboBox(Widget, CellEditable, CellLayout):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         active: int
         active_id: str | None
         button_sensitivity: SensitivityType
         child: Widget | None
         entry_text_column: int
-        has_entry: bool
+        @property
+        def has_entry(self) -> bool: ...
         has_frame: bool
         id_column: int
         model: TreeModel | None
         popup_fixed_width: bool
-        popup_shown: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def popup_shown(self) -> bool: ...
         accessible_role: AccessibleRole
         editing_canceled: bool
 
@@ -8298,6 +7291,8 @@ class ComboBox(Widget, CellEditable, CellLayout):
         id_column: int = ...,
         model: TreeModel | None = ...,
         popup_fixed_width: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        editing_canceled: bool = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -8328,8 +7323,6 @@ class ComboBox(Widget, CellEditable, CellLayout):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def do_activate(self) -> None: ...
     def do_changed(self) -> None: ...
@@ -8483,53 +7476,8 @@ class ComboBoxText(ComboBox):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ComboBox.Props):
-        active: int
-        active_id: str | None
-        button_sensitivity: SensitivityType
-        child: Widget | None
-        entry_text_column: int
-        has_entry: bool
-        has_frame: bool
-        id_column: int
-        model: TreeModel | None
-        popup_fixed_width: bool
-        popup_shown: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         editing_canceled: bool
 
@@ -8538,6 +7486,8 @@ class ComboBoxText(ComboBox):
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
+        editing_canceled: bool = ...,
         active: int = ...,
         active_id: str | None = ...,
         button_sensitivity: SensitivityType = ...,
@@ -8578,8 +7528,6 @@ class ComboBoxText(ComboBox):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editing_canceled: bool = ...,
     ) -> None: ...
     def append(self, id: str | None, text: str) -> None: ...
     def append_text(self, text: str) -> None: ...
@@ -8633,15 +7581,24 @@ class Constraint(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        constant: float
-        multiplier: float
-        relation: ConstraintRelation
-        source: ConstraintTarget | None
-        source_attribute: ConstraintAttribute
-        strength: int
-        target: ConstraintTarget | None
-        target_attribute: ConstraintAttribute
+        @property
+        def constant(self) -> float: ...
+        @property
+        def multiplier(self) -> float: ...
+        @property
+        def relation(self) -> ConstraintRelation: ...
+        @property
+        def source(self) -> ConstraintTarget | None: ...
+        @property
+        def source_attribute(self) -> ConstraintAttribute: ...
+        @property
+        def strength(self) -> int: ...
+        @property
+        def target(self) -> ConstraintTarget | None: ...
+        @property
+        def target_attribute(self) -> ConstraintAttribute: ...
 
     @property
     def props(self) -> Props: ...
@@ -8725,6 +7682,7 @@ class ConstraintGuide(GObject.Object, ConstraintTarget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         max_height: int
         max_width: int
@@ -8821,12 +7779,6 @@ class ConstraintLayoutChild(LayoutChild):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(LayoutChild.Props):
-        child_widget: Widget
-        layout_manager: LayoutManager
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self, *, child_widget: Widget = ..., layout_manager: LayoutManager = ...
     ) -> None: ...
@@ -8853,7 +7805,14 @@ class ConstraintLayoutClass(_gi.Struct):
     @property
     def parent_class(self) -> LayoutManagerClass: ...
 
-class ConstraintTarget(GObject.GInterface, Protocol): ...
+class ConstraintTarget(GObject.GInterface, Protocol):
+    """
+    Interface GtkConstraintTarget
+
+    Signals from GObject:
+      notify (GParam)
+    """
+
 class ConstraintTargetInterface(_gi.Struct): ...
 
 class CssLocation(_gi.Struct):
@@ -8895,6 +7854,7 @@ class CssProvider(GObject.Object, StyleProvider):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         prefers_color_scheme: InterfaceColorScheme
         prefers_contrast: InterfaceContrast
@@ -9181,70 +8141,11 @@ class Dialog(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def use_header_bar(self) -> int: ...
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -9254,6 +8155,7 @@ class Dialog(Window):
         self,
         *,
         use_header_bar: int = ...,
+        accessible_role: AccessibleRole = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
         decorated: bool = ...,
@@ -9308,7 +8210,6 @@ class Dialog(Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_action_widget(self, child: Widget, response_id: int) -> None: ...
     def add_button(self, button_text: str, response_id: int) -> Widget: ...
@@ -9382,15 +8283,20 @@ class DirectoryList(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         attributes: str | None
-        error: GLib.Error | None
+        @property
+        def error(self) -> GLib.Error | None: ...
         file: Gio.File | None
         io_priority: int
-        item_type: type[Any]
-        loading: bool
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def loading(self) -> bool: ...
         monitored: bool
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -9497,43 +8403,9 @@ class DragIcon(Widget, Native, Root):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -9542,6 +8414,7 @@ class DragIcon(Widget, Native, Root):
         self,
         *,
         child: Widget | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -9572,7 +8445,6 @@ class DragIcon(Widget, Native, Root):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     @staticmethod
     def create_widget_for_value(value: Any) -> Widget | None: ...
@@ -9641,17 +8513,10 @@ class DragSource(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GestureSingle.Props):
         actions: _Gdk4.DragAction
         content: _Gdk4.ContentProvider | None
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -9755,44 +8620,10 @@ class DrawingArea(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         content_height: int
         content_width: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -9804,6 +8635,7 @@ class DrawingArea(Widget):
         *,
         content_height: int = ...,
         content_width: int = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -9834,7 +8666,6 @@ class DrawingArea(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def do_resize(self, width: int, height: int) -> None: ...
     def get_content_height(self) -> int: ...
@@ -9892,14 +8723,14 @@ class DropControllerMotion(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        contains_pointer: bool
-        drop: _Gdk4.Drop | None
-        is_pointer: bool
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def contains_pointer(self) -> bool: ...
+        @property
+        def drop(self) -> _Gdk4.Drop | None: ...
+        @property
+        def is_pointer(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -10000,6 +8831,7 @@ class DropDown(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         enable_search: bool
         expression: Expression | None
@@ -10009,50 +8841,16 @@ class DropDown(Widget):
         model: Gio.ListModel | None
         search_match_mode: StringFilterMatchMode
         selected: int
-        selected_item: GObject.Object | None
+        @property
+        def selected_item(self) -> GObject.Object | None: ...
         show_arrow: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
     def props(self) -> Props: ...
-    # override
     def __init__(
         self,
+        *,
         enable_search: bool = ...,
         expression: Expression | None = ...,
         factory: ListItemFactory | None = ...,
@@ -10062,6 +8860,7 @@ class DropDown(Widget):
         search_match_mode: StringFilterMatchMode = ...,
         selected: int = ...,
         show_arrow: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -10092,7 +8891,6 @@ class DropDown(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_enable_search(self) -> bool: ...
     def get_expression(self) -> Expression | None: ...
@@ -10168,17 +8966,18 @@ class DropTarget(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
         actions: _Gdk4.DragAction
-        current_drop: _Gdk4.Drop | None
-        drop: _Gdk4.Drop | None
-        formats: _Gdk4.ContentFormats | None
+        @property
+        def current_drop(self) -> _Gdk4.Drop | None: ...
+        @property
+        def drop(self) -> _Gdk4.Drop | None: ...
+        @property
+        def formats(self) -> _Gdk4.ContentFormats | None: ...
         preload: bool
-        value: Any | None
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def value(self) -> Any | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -10238,13 +9037,10 @@ class DropTargetAsync(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
         actions: _Gdk4.DragAction
         formats: _Gdk4.ContentFormats | None
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -10423,49 +9219,17 @@ class EditableLabel(Widget, Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         editing: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -10476,6 +9240,13 @@ class EditableLabel(Widget, Editable):
         self,
         *,
         editing: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -10506,13 +9277,6 @@ class EditableLabel(Widget, Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def get_editing(self) -> bool: ...
     @classmethod
@@ -10614,50 +9378,8 @@ class EmojiChooser(Popover):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Popover.Props):
-        autohide: bool
-        cascade_popdown: bool
-        child: Widget | None
-        default_widget: Widget | None
-        has_arrow: bool
-        mnemonics_visible: bool
-        pointing_to: _Gdk4.Rectangle
-        position: PositionType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -10665,6 +9387,7 @@ class EmojiChooser(Popover):
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
         autohide: bool = ...,
         cascade_popdown: bool = ...,
         child: Widget | None = ...,
@@ -10703,7 +9426,6 @@ class EmojiChooser(Popover):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> EmojiChooser: ...
@@ -10834,6 +9556,7 @@ class Entry(Widget, CellEditable, Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activates_default: bool
         attributes: Pango.AttrList | None
@@ -10857,67 +9580,38 @@ class Entry(Widget, CellEditable, Editable):
         primary_icon_name: str
         primary_icon_paintable: _Gdk4.Paintable
         primary_icon_sensitive: bool
-        primary_icon_storage_type: ImageType
+        @property
+        def primary_icon_storage_type(self) -> ImageType: ...
         primary_icon_tooltip_markup: str
         primary_icon_tooltip_text: str
         progress_fraction: float
         progress_pulse_step: float
-        scroll_offset: int
+        @property
+        def scroll_offset(self) -> int: ...
         secondary_icon_activatable: bool
         secondary_icon_gicon: Gio.Icon
         secondary_icon_name: str
         secondary_icon_paintable: _Gdk4.Paintable
         secondary_icon_sensitive: bool
-        secondary_icon_storage_type: ImageType
+        @property
+        def secondary_icon_storage_type(self) -> ImageType: ...
         secondary_icon_tooltip_markup: str
         secondary_icon_tooltip_text: str
         show_emoji_icon: bool
         tabs: Pango.TabArray | None
-        text_length: int
+        @property
+        def text_length(self) -> int: ...
         truncate_multiline: bool
         visibility: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         editing_canceled: bool
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -10966,6 +9660,14 @@ class Entry(Widget, CellEditable, Editable):
         tabs: Pango.TabArray | None = ...,
         truncate_multiline: bool = ...,
         visibility: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        editing_canceled: bool = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -10996,14 +9698,6 @@ class Entry(Widget, CellEditable, Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editing_canceled: bool = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def do_activate(self) -> None: ...
     def get_activates_default(self) -> bool: ...
@@ -11117,8 +9811,10 @@ class EntryBuffer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        length: int
+        @property
+        def length(self) -> int: ...
         max_length: int
         text: str
 
@@ -11216,8 +9912,10 @@ class EntryCompletion(GObject.Object, Buildable, CellLayout):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         inline_completion: bool
         inline_selection: bool
         minimum_key_length: int
@@ -11288,11 +9986,13 @@ class EventController(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         name: str | None
         propagation_limit: PropagationLimit
         propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def widget(self) -> Widget | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -11347,13 +10047,12 @@ class EventControllerFocus(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        contains_focus: bool
-        is_focus: bool
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def contains_focus(self) -> bool: ...
+        @property
+        def is_focus(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -11397,14 +10096,6 @@ class EventControllerKey(EventController):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EventController.Props):
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -11444,14 +10135,6 @@ class EventControllerLegacy(EventController):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EventController.Props):
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -11493,13 +10176,12 @@ class EventControllerMotion(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        contains_pointer: bool
-        is_pointer: bool
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def contains_pointer(self) -> bool: ...
+        @property
+        def is_pointer(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -11546,12 +10228,9 @@ class EventControllerScroll(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
         flags: EventControllerScrollFlags
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -11598,12 +10277,6 @@ class EveryFilter(MultiFilter):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(MultiFilter.Props):
-        item_type: type[Any]
-        n_items: int
-
-    @property
-    def props(self) -> Props: ...
     @classmethod
     def new(cls) -> EveryFilter: ...
 
@@ -11688,6 +10361,7 @@ class Expander(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
         expanded: bool
@@ -11696,41 +10370,6 @@ class Expander(Widget):
         resize_toplevel: bool
         use_markup: bool
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -11745,6 +10384,7 @@ class Expander(Widget):
         resize_toplevel: bool = ...,
         use_markup: bool = ...,
         use_underline: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -11775,7 +10415,6 @@ class Expander(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     def get_expanded(self) -> bool: ...
@@ -11969,82 +10608,28 @@ class FileChooserDialog(Dialog, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action: FileChooserAction
         create_folders: bool
         filter: FileFilter | None
-        filters: Gio.ListModel
+        @property
+        def filters(self) -> Gio.ListModel: ...
         select_multiple: bool
-        shortcut_folders: Gio.ListModel
-        startup_id: str
+        @property
+        def shortcut_folders(self) -> Gio.ListModel: ...
 
     @property
     def props(self) -> Props: ...
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
+        action: FileChooserAction = ...,
+        create_folders: bool = ...,
+        filter: FileFilter = ...,
+        select_multiple: bool = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -12100,11 +10685,6 @@ class FileChooserDialog(Dialog, FileChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action: FileChooserAction = ...,
-        create_folders: bool = ...,
-        filter: FileFilter = ...,
-        select_multiple: bool = ...,
     ) -> None: ...
 
 class FileChooserNative(NativeDialog, FileChooser):
@@ -12134,19 +10714,18 @@ class FileChooserNative(NativeDialog, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(NativeDialog.Props):
         accept_label: str | None
         cancel_label: str | None
-        modal: bool
-        title: str | None
-        transient_for: Window | None
-        visible: bool
         action: FileChooserAction
         create_folders: bool
         filter: FileFilter | None
-        filters: Gio.ListModel
+        @property
+        def filters(self) -> Gio.ListModel: ...
         select_multiple: bool
-        shortcut_folders: Gio.ListModel
+        @property
+        def shortcut_folders(self) -> Gio.ListModel: ...
 
     @property
     def props(self) -> Props: ...
@@ -12155,14 +10734,14 @@ class FileChooserNative(NativeDialog, FileChooser):
         *,
         accept_label: str | None = ...,
         cancel_label: str | None = ...,
-        modal: bool = ...,
-        title: str = ...,
-        transient_for: Window | None = ...,
-        visible: bool = ...,
         action: FileChooserAction = ...,
         create_folders: bool = ...,
         filter: FileFilter = ...,
         select_multiple: bool = ...,
+        modal: bool = ...,
+        title: str = ...,
+        transient_for: Window | None = ...,
+        visible: bool = ...,
     ) -> None: ...
     def get_accept_label(self) -> str | None: ...
     def get_cancel_label(self) -> str | None: ...
@@ -12274,52 +10853,22 @@ class FileChooserWidget(Widget, FileChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         search_mode: bool
-        show_time: bool
-        subtitle: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def show_time(self) -> bool: ...
+        @property
+        def subtitle(self) -> str: ...
         accessible_role: AccessibleRole
         action: FileChooserAction
         create_folders: bool
         filter: FileFilter | None
-        filters: Gio.ListModel
+        @property
+        def filters(self) -> Gio.ListModel: ...
         select_multiple: bool
-        shortcut_folders: Gio.ListModel
+        @property
+        def shortcut_folders(self) -> Gio.ListModel: ...
 
     @property
     def props(self) -> Props: ...
@@ -12327,6 +10876,11 @@ class FileChooserWidget(Widget, FileChooser):
         self,
         *,
         search_mode: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        action: FileChooserAction = ...,
+        create_folders: bool = ...,
+        filter: FileFilter = ...,
+        select_multiple: bool = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -12357,11 +10911,6 @@ class FileChooserWidget(Widget, FileChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action: FileChooserAction = ...,
-        create_folders: bool = ...,
-        filter: FileFilter = ...,
-        select_multiple: bool = ...,
     ) -> None: ...
     @classmethod
     def new(cls, action: FileChooserAction) -> FileChooserWidget: ...
@@ -12390,6 +10939,7 @@ class FileDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accept_label: str | None
         default_filter: FileFilter | None
@@ -12402,12 +10952,12 @@ class FileDialog(GObject.Object):
 
     @property
     def props(self) -> Props: ...
-    # override
     def __init__(
         self,
+        *,
         accept_label: str | None = ...,
         default_filter: FileFilter | None = ...,
-        filters: Gio.ListModel[FileFilter] | None = ...,
+        filters: Gio.ListModel | None = ...,
         initial_file: Gio.File | None = ...,
         initial_folder: Gio.File | None = ...,
         initial_name: str | None = ...,
@@ -12542,11 +11092,9 @@ class FileFilter(Filter, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Filter.Props):
         name: str | None
-        mime_types: list[str]
-        patterns: list[str]
-        suffixes: list[str]
 
     @property
     def props(self) -> Props: ...
@@ -12590,6 +11138,7 @@ class FileLauncher(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         always_ask: bool
         file: Gio.File | None
@@ -12708,13 +11257,17 @@ class FilterListModel(GObject.Object, Gio.ListModel, SectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         filter: Filter | None
         incremental: bool
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
-        pending: int
+        @property
+        def n_items(self) -> int: ...
+        @property
+        def pending(self) -> int: ...
         watch_items: bool
 
     @property
@@ -12818,42 +11371,8 @@ class Fixed(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -12863,6 +11382,7 @@ class Fixed(Widget):
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -12893,7 +11413,6 @@ class Fixed(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child_position(self, widget: Widget) -> tuple[float, float]: ...
     def get_child_transform(self, widget: Widget) -> Gsk.Transform | None: ...
@@ -12956,10 +11475,9 @@ class FixedLayoutChild(LayoutChild):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(LayoutChild.Props):
         transform: Gsk.Transform | None
-        child_widget: Widget
-        layout_manager: LayoutManager
 
     @property
     def props(self) -> Props: ...
@@ -13020,10 +11538,13 @@ class FlattenListModel(GObject.Object, Gio.ListModel, SectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -13130,6 +11651,7 @@ class FlowBox(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         accept_unpaired_release: bool
         activate_on_single_click: bool
@@ -13139,41 +11661,6 @@ class FlowBox(Widget, Orientable):
         min_children_per_line: int
         row_spacing: int
         selection_mode: SelectionMode
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -13190,6 +11677,8 @@ class FlowBox(Widget, Orientable):
         min_children_per_line: int = ...,
         row_spacing: int = ...,
         selection_mode: SelectionMode = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -13220,8 +11709,6 @@ class FlowBox(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def append(self, child: Widget) -> None: ...
     def bind_model(
@@ -13341,43 +11828,9 @@ class FlowBoxChild(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -13388,6 +11841,7 @@ class FlowBoxChild(Widget):
         self,
         *,
         child: Widget | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -13418,7 +11872,6 @@ class FlowBoxChild(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def changed(self) -> None: ...
     def do_activate(self) -> None: ...
@@ -13524,50 +11977,17 @@ class FontButton(Widget, FontChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         modal: bool
         title: str
         use_font: bool
         use_size: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         font: str | None
         font_desc: Pango.FontDescription | None
-        font_features: str
+        @property
+        def font_features(self) -> str: ...
         language: str
         level: FontChooserLevel
         preview_text: str
@@ -13582,6 +12002,13 @@ class FontButton(Widget, FontChooser):
         title: str = ...,
         use_font: bool = ...,
         use_size: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        font: str = ...,
+        font_desc: Pango.FontDescription = ...,
+        language: str = ...,
+        level: FontChooserLevel = ...,
+        preview_text: str = ...,
+        show_preview_entry: bool = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -13612,13 +12039,6 @@ class FontButton(Widget, FontChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        font: str = ...,
-        font_desc: Pango.FontDescription = ...,
-        language: str = ...,
-        level: FontChooserLevel = ...,
-        preview_text: str = ...,
-        show_preview_entry: bool = ...,
     ) -> None: ...
     def get_modal(self) -> bool: ...
     def get_title(self) -> str: ...
@@ -13773,83 +12193,30 @@ class FontChooserDialog(Dialog, FontChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         font: str | None
         font_desc: Pango.FontDescription | None
-        font_features: str
+        @property
+        def font_features(self) -> str: ...
         language: str
         level: FontChooserLevel
         preview_text: str
         show_preview_entry: bool
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
+        font: str = ...,
+        font_desc: Pango.FontDescription = ...,
+        language: str = ...,
+        level: FontChooserLevel = ...,
+        preview_text: str = ...,
+        show_preview_entry: bool = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -13905,13 +12272,6 @@ class FontChooserDialog(Dialog, FontChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        font: str = ...,
-        font_desc: Pango.FontDescription = ...,
-        language: str = ...,
-        level: FontChooserLevel = ...,
-        preview_text: str = ...,
-        show_preview_entry: bool = ...,
     ) -> None: ...
     @classmethod
     def new(
@@ -14017,47 +12377,15 @@ class FontChooserWidget(Widget, FontChooser):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        tweak_action: Gio.Action
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        @property
+        def tweak_action(self) -> Gio.Action: ...
         accessible_role: AccessibleRole
         font: str | None
         font_desc: Pango.FontDescription | None
-        font_features: str
+        @property
+        def font_features(self) -> str: ...
         language: str
         level: FontChooserLevel
         preview_text: str
@@ -14068,6 +12396,13 @@ class FontChooserWidget(Widget, FontChooser):
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
+        font: str = ...,
+        font_desc: Pango.FontDescription = ...,
+        language: str = ...,
+        level: FontChooserLevel = ...,
+        preview_text: str = ...,
+        show_preview_entry: bool = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -14098,13 +12433,6 @@ class FontChooserWidget(Widget, FontChooser):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        font: str = ...,
-        font_desc: Pango.FontDescription = ...,
-        language: str = ...,
-        level: FontChooserLevel = ...,
-        preview_text: str = ...,
-        show_preview_entry: bool = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> FontChooserWidget: ...
@@ -14130,6 +12458,7 @@ class FontDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         filter: Filter | None
         font_map: Pango.FontMap | None
@@ -14277,6 +12606,7 @@ class FontDialogButton(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         dialog: FontDialog | None
         font_desc: Pango.FontDescription | None
@@ -14285,41 +12615,6 @@ class FontDialogButton(Widget):
         level: FontLevel
         use_font: bool
         use_size: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -14334,6 +12629,7 @@ class FontDialogButton(Widget):
         level: FontLevel = ...,
         use_font: bool = ...,
         use_size: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -14364,7 +12660,6 @@ class FontDialogButton(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_dialog(self) -> FontDialog | None: ...
     def get_font_desc(self) -> Pango.FontDescription | None: ...
@@ -14477,46 +12772,12 @@ class Frame(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
         label: str | None
         label_widget: Widget | None
         label_xalign: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -14530,6 +12791,7 @@ class Frame(Widget):
         label: str | None = ...,
         label_widget: Widget | None = ...,
         label_xalign: float = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -14560,7 +12822,6 @@ class Frame(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def do_compute_child_allocation(self, allocation: _Gdk4.Rectangle) -> None: ...
     def get_child(self) -> Widget | None: ...
@@ -14669,49 +12930,17 @@ class GLArea(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         allowed_apis: _Gdk4.GLAPI
-        api: _Gdk4.GLAPI
+        @property
+        def api(self) -> _Gdk4.GLAPI: ...
         auto_render: bool
-        context: _Gdk4.GLContext | None
+        @property
+        def context(self) -> _Gdk4.GLContext | None: ...
         has_depth_buffer: bool
         has_stencil_buffer: bool
         use_es: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -14726,6 +12955,7 @@ class GLArea(Widget):
         has_depth_buffer: bool = ...,
         has_stencil_buffer: bool = ...,
         use_es: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -14756,7 +12986,6 @@ class GLArea(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def attach_buffers(self) -> None: ...
     def do_render(self, context: _Gdk4.GLContext) -> bool: ...
@@ -14828,12 +13057,10 @@ class Gesture(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def n_points(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -14914,18 +13141,6 @@ class GestureClick(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -14982,18 +13197,6 @@ class GestureDrag(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -15054,16 +13257,9 @@ class GestureLongPress(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GestureSingle.Props):
         delay_factor: float
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -15132,16 +13328,9 @@ class GesturePan(GestureDrag):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GestureDrag.Props):
         orientation: Orientation
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -15197,15 +13386,6 @@ class GestureRotate(Gesture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gesture.Props):
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -15254,15 +13434,11 @@ class GestureSingle(Gesture):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gesture.Props):
         button: int
         exclusive: bool
         touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -15332,16 +13508,9 @@ class GestureStylus(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GestureSingle.Props):
         stylus_only: bool
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
 
     @property
     def props(self) -> Props: ...
@@ -15406,18 +13575,6 @@ class GestureSwipe(GestureSingle):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(GestureSingle.Props):
-        button: int
-        exclusive: bool
-        touch_only: bool
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -15468,15 +13625,6 @@ class GestureZoom(Gesture):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(Gesture.Props):
-        n_points: int
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-
-    @property
-    def props(self) -> Props: ...
     def __init__(
         self,
         *,
@@ -15562,45 +13710,11 @@ class GraphicsOffload(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         black_background: bool
         child: Widget | None
         enabled: GraphicsOffloadEnabled
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -15611,6 +13725,7 @@ class GraphicsOffload(Widget):
         black_background: bool = ...,
         child: Widget | None = ...,
         enabled: GraphicsOffloadEnabled = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -15641,7 +13756,6 @@ class GraphicsOffload(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_black_background(self) -> bool: ...
     def get_child(self) -> Widget | None: ...
@@ -15736,47 +13850,13 @@ class Grid(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         baseline_row: int
         column_homogeneous: bool
         column_spacing: int
         row_homogeneous: bool
         row_spacing: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -15792,6 +13872,8 @@ class Grid(Widget, Orientable):
         column_spacing: int = ...,
         row_homogeneous: bool = ...,
         row_spacing: int = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -15822,8 +13904,6 @@ class Grid(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def attach(
         self, child: Widget, column: int, row: int, width: int, height: int
@@ -15893,6 +13973,7 @@ class GridLayout(LayoutManager):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(LayoutManager.Props):
         baseline_row: int
         column_homogeneous: bool
@@ -15949,13 +14030,12 @@ class GridLayoutChild(LayoutChild):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(LayoutChild.Props):
         column: int
         column_span: int
         row: int
         row_span: int
-        child_widget: Widget
-        layout_manager: LayoutManager
 
     @property
     def props(self) -> Props: ...
@@ -16081,6 +14161,7 @@ class GridView(ListBase):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ListBase.Props):
         enable_rubberband: bool
         factory: ListItemFactory | None
@@ -16089,43 +14170,8 @@ class GridView(ListBase):
         model: SelectionModel | None
         single_click_activate: bool
         tab_behavior: ListTabBehavior
-        orientation: Orientation
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
+        orientation: Orientation
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
         vadjustment: Adjustment | None
@@ -16143,7 +14189,12 @@ class GridView(ListBase):
         model: SelectionModel | None = ...,
         single_click_activate: bool = ...,
         tab_behavior: ListTabBehavior = ...,
+        accessible_role: AccessibleRole = ...,
         orientation: Orientation = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -16174,11 +14225,6 @@ class GridView(ListBase):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def get_enable_rubberband(self) -> bool: ...
     def get_factory(self) -> ListItemFactory | None: ...
@@ -16276,46 +14322,12 @@ class HeaderBar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         decoration_layout: str | None
         show_title_buttons: bool
         title_widget: Widget | None
         use_native_controls: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -16327,6 +14339,7 @@ class HeaderBar(Widget):
         show_title_buttons: bool = ...,
         title_widget: Widget | None = ...,
         use_native_controls: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -16357,7 +14370,6 @@ class HeaderBar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_decoration_layout(self) -> str | None: ...
     def get_show_title_buttons(self) -> bool: ...
@@ -16398,6 +14410,7 @@ class IMContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         input_hints: InputHints
         input_purpose: InputPurpose
@@ -16541,12 +14554,6 @@ class IMContextSimple(IMContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(IMContext.Props):
-        input_hints: InputHints
-        input_purpose: InputPurpose
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> IMContext: ...
     @property
@@ -16597,12 +14604,6 @@ class IMMulticontext(IMContext):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(IMContext.Props):
-        input_hints: InputHints
-        input_purpose: InputPurpose
-
-    @property
-    def props(self) -> Props: ...
     @property
     def object(self) -> IMContext: ...
     @property
@@ -16653,9 +14654,12 @@ class IconPaintable(GObject.Object, _Gdk4.Paintable, SymbolicPaintable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        file: Gio.File | None
-        icon_name: str | None
+        @property
+        def file(self) -> Gio.File | None: ...
+        @property
+        def icon_name(self) -> str | None: ...
         is_symbolic: bool
         scale: int
         size: int
@@ -16712,12 +14716,14 @@ class IconTheme(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         display: _Gdk4.Display | None
-        icon_names: list[str]
+        @property
+        def icon_names(self) -> list[str]: ...
         resource_path: list[str] | None
         search_path: list[str] | None
-        theme_name: str
+        theme_name: str | None
 
     @property
     def props(self) -> Props: ...
@@ -16861,9 +14867,11 @@ class IconView(Widget, CellLayout, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activate_on_single_click: bool
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         column_spacing: int
         columns: int
         item_orientation: Orientation
@@ -16879,41 +14887,6 @@ class IconView(Widget, CellLayout, Scrollable):
         spacing: int
         text_column: int
         tooltip_column: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
@@ -16942,6 +14915,11 @@ class IconView(Widget, CellLayout, Scrollable):
         spacing: int = ...,
         text_column: int = ...,
         tooltip_column: int = ...,
+        accessible_role: AccessibleRole = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -16972,11 +14950,6 @@ class IconView(Widget, CellLayout, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def create_drag_icon(self, path: TreePath) -> _Gdk4.Paintable | None: ...
     def enable_model_drag_dest(
@@ -17153,6 +15126,7 @@ class Image(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         file: str
         gicon: Gio.Icon | None
@@ -17161,43 +15135,9 @@ class Image(Widget):
         paintable: _Gdk4.Paintable | None
         pixel_size: int
         resource: str
-        storage_type: ImageType
+        @property
+        def storage_type(self) -> ImageType: ...
         use_fallback: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -17213,6 +15153,7 @@ class Image(Widget):
         pixel_size: int = ...,
         resource: str = ...,
         use_fallback: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -17243,7 +15184,6 @@ class Image(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def clear(self) -> None: ...
     def get_gicon(self) -> Gio.Icon | None: ...
@@ -17350,45 +15290,11 @@ class InfoBar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         message_type: MessageType
         revealed: bool
         show_close_button: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -17399,6 +15305,7 @@ class InfoBar(Widget):
         message_type: MessageType = ...,
         revealed: bool = ...,
         show_close_button: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -17429,7 +15336,6 @@ class InfoBar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_action_widget(self, child: Widget, response_id: int) -> None: ...
     def add_button(self, button_text: str, response_id: int) -> Button: ...
@@ -17527,8 +15433,10 @@ class Inscription(Widget, AccessibleText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         attributes: Pango.AttrList | None
+        markup: str | None
         min_chars: int
         min_lines: int
         nat_chars: int
@@ -17538,43 +15446,7 @@ class Inscription(Widget, AccessibleText):
         wrap_mode: Pango.WrapMode
         xalign: float
         yalign: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        markup: str | None
 
     @property
     def props(self) -> Props: ...
@@ -17592,6 +15464,7 @@ class Inscription(Widget, AccessibleText):
         wrap_mode: Pango.WrapMode = ...,
         xalign: float = ...,
         yalign: float = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -17622,7 +15495,6 @@ class Inscription(Widget, AccessibleText):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_attributes(self) -> Pango.AttrList | None: ...
     def get_min_chars(self) -> int: ...
@@ -17677,9 +15549,12 @@ class KeyvalTrigger(ShortcutTrigger):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ShortcutTrigger.Props):
-        keyval: int
-        modifiers: _Gdk4.ModifierType
+        @property
+        def keyval(self) -> int: ...
+        @property
+        def modifiers(self) -> _Gdk4.ModifierType: ...
 
     @property
     def props(self) -> Props: ...
@@ -17788,6 +15663,7 @@ class Label(Widget, AccessibleText):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         attributes: Pango.AttrList | None
         ellipsize: Pango.EllipsizeMode
@@ -17796,7 +15672,8 @@ class Label(Widget, AccessibleText):
         label: str
         lines: int
         max_width_chars: int
-        mnemonic_keyval: int
+        @property
+        def mnemonic_keyval(self) -> int: ...
         mnemonic_widget: Widget | None
         natural_wrap_mode: NaturalWrapMode
         selectable: bool
@@ -17809,41 +15686,6 @@ class Label(Widget, AccessibleText):
         wrap_mode: Pango.WrapMode
         xalign: float
         yalign: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -17870,6 +15712,7 @@ class Label(Widget, AccessibleText):
         wrap_mode: Pango.WrapMode = ...,
         xalign: float = ...,
         yalign: float = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -17900,7 +15743,6 @@ class Label(Widget, AccessibleText):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_attributes(self) -> Pango.AttrList | None: ...
     def get_current_uri(self) -> str | None: ...
@@ -17973,9 +15815,12 @@ class LayoutChild(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child_widget: Widget
-        layout_manager: LayoutManager
+        @property
+        def child_widget(self) -> Widget: ...
+        @property
+        def layout_manager(self) -> LayoutManager: ...
 
     @property
     def props(self) -> Props: ...
@@ -18146,47 +15991,13 @@ class LevelBar(Widget, AccessibleRange, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         inverted: bool
         max_value: float
         min_value: float
         mode: LevelBarMode
         value: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -18200,6 +16011,8 @@ class LevelBar(Widget, AccessibleRange, Orientable):
         min_value: float = ...,
         mode: LevelBarMode = ...,
         value: float = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -18230,8 +16043,6 @@ class LevelBar(Widget, AccessibleRange, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_offset_value(self, name: str, value: float) -> None: ...
     def get_inverted(self) -> bool: ...
@@ -18337,50 +16148,10 @@ class LinkButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         uri: str
         visited: bool
-        can_shrink: bool
-        child: Widget | None
-        has_frame: bool
-        icon_name: str | None
-        label: str | None
-        use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -18392,6 +16163,9 @@ class LinkButton(Button):
         *,
         uri: str = ...,
         visited: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_shrink: bool = ...,
         child: Widget | None = ...,
         has_frame: bool = ...,
@@ -18428,9 +16202,6 @@ class LinkButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_uri(self) -> str: ...
     def get_visited(self) -> bool: ...
@@ -18509,43 +16280,9 @@ class ListBase(Widget, Orientable, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         orientation: Orientation
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
@@ -18558,6 +16295,11 @@ class ListBase(Widget, Orientable, Scrollable):
         self,
         *,
         orientation: Orientation = ...,
+        accessible_role: AccessibleRole = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -18588,11 +16330,6 @@ class ListBase(Widget, Orientable, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
 
 class ListBaseClass(_gi.Struct): ...
@@ -18680,47 +16417,13 @@ class ListBox(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         accept_unpaired_release: bool
         activate_on_single_click: bool
         selection_mode: SelectionMode
         show_separators: bool
         tab_behavior: ListTabBehavior
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -18733,6 +16436,7 @@ class ListBox(Widget):
         selection_mode: SelectionMode = ...,
         show_separators: bool = ...,
         tab_behavior: ListTabBehavior = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -18763,7 +16467,6 @@ class ListBox(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def append(self, child: Widget) -> None: ...
     def bind_model(
@@ -18887,45 +16590,11 @@ class ListBoxRow(Widget, Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activatable: bool
         child: Widget | None
         selectable: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -18940,6 +16609,9 @@ class ListBoxRow(Widget, Actionable):
         activatable: bool = ...,
         child: Widget | None = ...,
         selectable: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -18970,9 +16642,6 @@ class ListBoxRow(Widget, Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def changed(self) -> None: ...
     def do_activate(self) -> None: ...
@@ -19024,12 +16693,17 @@ class ListHeader(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         child: Widget | None
-        end: int
-        item: GObject.Object | None
-        n_items: int
-        start: int
+        @property
+        def end(self) -> int: ...
+        @property
+        def item(self) -> GObject.Object | None: ...
+        @property
+        def n_items(self) -> int: ...
+        @property
+        def start(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -19067,16 +16741,20 @@ class ListItem(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accessible_description: str
         accessible_label: str
         activatable: bool
         child: Widget | None
         focusable: bool
-        item: GObject.Object | None
-        position: int
+        @property
+        def item(self) -> GObject.Object | None: ...
+        @property
+        def position(self) -> int: ...
         selectable: bool
-        selected: bool
+        @property
+        def selected(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -19107,10 +16785,23 @@ class ListItem(GObject.Object):
     def set_selectable(self, selectable: bool) -> None: ...
 
 class ListItemClass(_gi.Struct): ...
-class ListItemFactory(GObject.Object): ...
+
+class ListItemFactory(GObject.Object):
+    """
+    :Constructors:
+
+    ::
+
+        ListItemFactory(**properties)
+
+    Object GtkListItemFactory
+
+    Signals from GObject:
+      notify (GParam)
+    """
+
 class ListItemFactoryClass(_gi.Struct): ...
 
-# override
 class ListStore(
     GObject.Object, Buildable, TreeDragDest, TreeDragSource, TreeModel, TreeSortable
 ):
@@ -19120,37 +16811,39 @@ class ListStore(
     ::
 
         ListStore(**properties)
-        new(types:list) -> ListStore
+        new(types:list) -> Gtk.ListStore
 
     Object GtkListStore
 
     Signals from GtkTreeModel:
-      rowchanged (GtkTreePath, GtkTreeIter)
-      rowinserted (GtkTreePath, GtkTreeIter)
-      rowhaschildtoggled (GtkTreePath, GtkTreeIter)
-      rowdeleted (GtkTreePath)
-      rowsreordered (GtkTreePath, GtkTreeIter, gpointer)
+      row-changed (GtkTreePath, GtkTreeIter)
+      row-inserted (GtkTreePath, GtkTreeIter)
+      row-has-child-toggled (GtkTreePath, GtkTreeIter)
+      row-deleted (GtkTreePath)
+      rows-reordered (GtkTreePath, GtkTreeIter, gpointer)
 
     Signals from GtkTreeSortable:
-      sortcolumnchanged ()
+      sort-column-changed ()
 
     Signals from GObject:
       notify (GParam)
     """
-
-    parent: GObject.Object = ...
-
+    @property
+    def parent(self) -> GObject.Object: ...
     @property
     def priv(self) -> ListStorePrivate: ...
-    def __init__(self, *args: Any) -> None: ...
+    # override
     def append(self, row: list[Any] | tuple[Any, ...] | None = None) -> TreeIter: ...
     def clear(self) -> None: ...
+    # override
     def insert(
         self, position: int, row: list[Any] | tuple[Any, ...] | None = None
     ) -> TreeIter: ...
+    # override
     def insert_after(
         self, sibling: TreeIter, row: list[Any] | tuple[Any, ...] | None = None
     ) -> TreeIter: ...
+    # override
     def insert_before(
         self, sibling: TreeIter, row: list[Any] | tuple[Any, ...] | None = None
     ) -> TreeIter: ...
@@ -19165,11 +16858,14 @@ class ListStore(
     def move_before(self, iter: TreeIter, position: TreeIter | None = None) -> None: ...
     @classmethod
     def new(cls, types: Sequence[type[Any]]) -> ListStore: ...
+    # override
     def prepend(self, row: list[Any] | tuple[Any, ...] | None = None) -> TreeIter: ...
     def remove(self, iter: TreeIter) -> bool: ...
     def reorder(self, new_order: Sequence[int]) -> None: ...
+    # override
     def set(self, treeiter: TreeIter, *args: dict[int, Any]) -> None: ...
     def set_column_types(self, types: Sequence[type[Any]]) -> None: ...
+    # override
     def set_value(self, treeiter: TreeIter, column: int, value: Any) -> None: ...
     def swap(self, a: TreeIter, b: TreeIter) -> None: ...
 
@@ -19269,6 +16965,7 @@ class ListView(ListBase):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ListBase.Props):
         enable_rubberband: bool
         factory: ListItemFactory | None
@@ -19277,43 +16974,8 @@ class ListView(ListBase):
         show_separators: bool
         single_click_activate: bool
         tab_behavior: ListTabBehavior
-        orientation: Orientation
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
+        orientation: Orientation
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
         vadjustment: Adjustment | None
@@ -19331,7 +16993,12 @@ class ListView(ListBase):
         show_separators: bool = ...,
         single_click_activate: bool = ...,
         tab_behavior: ListTabBehavior = ...,
+        accessible_role: AccessibleRole = ...,
         orientation: Orientation = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -19362,11 +17029,6 @@ class ListView(ListBase):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def get_enable_rubberband(self) -> bool: ...
     def get_factory(self) -> ListItemFactory | None: ...
@@ -19478,6 +17140,7 @@ class LockButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         permission: Gio.Permission | None
         text_lock: str
@@ -19485,47 +17148,6 @@ class LockButton(Button):
         tooltip_lock: str
         tooltip_not_authorized: str
         tooltip_unlock: str
-        can_shrink: bool
-        child: Widget | None
-        has_frame: bool
-        icon_name: str | None
-        label: str | None
-        use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -19541,6 +17163,9 @@ class LockButton(Button):
         tooltip_lock: str = ...,
         tooltip_not_authorized: str = ...,
         tooltip_unlock: str = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_shrink: bool = ...,
         child: Widget | None = ...,
         has_frame: bool = ...,
@@ -19577,9 +17202,6 @@ class LockButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_permission(self) -> Gio.Permission | None: ...
     @classmethod
@@ -19612,11 +17234,15 @@ class MapListModel(GObject.Object, Gio.ListModel, SectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        has_map: bool
-        item_type: type[Any]
+        @property
+        def has_map(self) -> bool: ...
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -19715,43 +17341,9 @@ class MediaControls(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         media_stream: MediaStream | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -19760,6 +17352,7 @@ class MediaControls(Widget):
         self,
         *,
         media_stream: MediaStream | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -19790,7 +17383,6 @@ class MediaControls(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_media_stream(self) -> MediaStream | None: ...
     @classmethod
@@ -19853,22 +17445,10 @@ class MediaFile(MediaStream):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(MediaStream.Props):
         file: Gio.File | None
         input_stream: Gio.InputStream | None
-        duration: int
-        ended: bool
-        error: GLib.Error | None
-        has_audio: bool
-        has_video: bool
-        loop: bool
-        muted: bool
-        playing: bool
-        prepared: bool
-        seekable: bool
-        seeking: bool
-        timestamp: int
-        volume: float
 
     @property
     def props(self) -> Props: ...
@@ -19951,19 +17531,29 @@ class MediaStream(GObject.Object, _Gdk4.Paintable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        duration: int
-        ended: bool
-        error: GLib.Error | None
-        has_audio: bool
-        has_video: bool
+        @property
+        def duration(self) -> int: ...
+        @property
+        def ended(self) -> bool: ...
+        @property
+        def error(self) -> GLib.Error | None: ...
+        @property
+        def has_audio(self) -> bool: ...
+        @property
+        def has_video(self) -> bool: ...
         loop: bool
         muted: bool
         playing: bool
-        prepared: bool
-        seekable: bool
-        seeking: bool
-        timestamp: int
+        @property
+        def prepared(self) -> bool: ...
+        @property
+        def seekable(self) -> bool: ...
+        @property
+        def seeking(self) -> bool: ...
+        @property
+        def timestamp(self) -> int: ...
         volume: float
 
     @property
@@ -20122,6 +17712,7 @@ class MenuButton(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         active: bool
         always_show_arrow: bool
@@ -20135,41 +17726,6 @@ class MenuButton(Widget):
         popover: Popover | None
         primary: bool
         use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -20189,6 +17745,7 @@ class MenuButton(Widget):
         popover: Popover | None = ...,
         primary: bool = ...,
         use_underline: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -20219,7 +17776,6 @@ class MenuButton(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_active(self) -> bool: ...
     def get_always_show_arrow(self) -> bool: ...
@@ -20369,77 +17925,16 @@ class MessageDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        message_area: Widget
+        @property
+        def message_area(self) -> Widget: ...
         message_type: MessageType
         secondary_text: str
         secondary_use_markup: bool
         text: str
         use_markup: bool
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        buttons: ButtonsType
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -20454,6 +17949,7 @@ class MessageDialog(Dialog):
         secondary_use_markup: bool = ...,
         text: str = ...,
         use_markup: bool = ...,
+        accessible_role: AccessibleRole = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -20509,7 +18005,6 @@ class MessageDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_message_area(self) -> Widget: ...
     def set_markup(self, str: str) -> None: ...
@@ -20551,8 +18046,10 @@ class MnemonicTrigger(ShortcutTrigger):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ShortcutTrigger.Props):
-        keyval: int
+        @property
+        def keyval(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -20601,19 +18098,12 @@ class MountOperation(Gio.MountOperation):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Gio.MountOperation.Props):
         display: _Gdk4.Display
-        is_showing: bool
+        @property
+        def is_showing(self) -> bool: ...
         parent: Window | None
-        anonymous: bool
-        choice: int
-        domain: str | None
-        is_tcrypt_hidden_volume: bool
-        is_tcrypt_system_volume: bool
-        password: str | None
-        password_save: Gio.PasswordSave
-        pim: int
-        username: str | None
 
     @property
     def props(self) -> Props: ...
@@ -20680,9 +18170,12 @@ class MultiFilter(Filter, Gio.ListModel, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Filter.Props):
-        item_type: type[Any]
-        n_items: int
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -20719,10 +18212,13 @@ class MultiSelection(GObject.Object, Gio.ListModel, SectionModel, SelectionModel
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -20767,9 +18263,12 @@ class MultiSorter(Sorter, Gio.ListModel, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Sorter.Props):
-        item_type: type[Any]
-        n_items: int
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -20806,8 +18305,10 @@ class NamedAction(ShortcutAction):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ShortcutAction.Props):
-        action_name: str
+        @property
+        def action_name(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -20855,6 +18356,7 @@ class NativeDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         modal: bool
         title: str | None
@@ -20952,10 +18454,13 @@ class NoSelection(GObject.Object, Gio.ListModel, SectionModel, SelectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -21064,50 +18569,17 @@ class Notebook(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         enable_popup: bool
         group_name: str | None
         page: int
-        pages: Gio.ListModel
+        @property
+        def pages(self) -> Gio.ListModel: ...
         scrollable: bool
         show_border: bool
         show_tabs: bool
         tab_pos: PositionType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -21122,6 +18594,7 @@ class Notebook(Widget):
         show_border: bool = ...,
         show_tabs: bool = ...,
         tab_pos: PositionType = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -21152,7 +18625,6 @@ class Notebook(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def append_page(self, child: Widget, tab_label: Widget | None = None) -> int: ...
     def append_page_menu(
@@ -21246,14 +18718,18 @@ class NotebookPage(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child: Widget
+        @property
+        def child(self) -> Widget: ...
         detachable: bool
-        menu: Widget
+        @property
+        def menu(self) -> Widget: ...
         menu_label: str
         position: int
         reorderable: bool
-        tab: Widget
+        @property
+        def tab(self) -> Widget: ...
         tab_expand: bool
         tab_fill: bool
         tab_label: str
@@ -21315,6 +18791,7 @@ class NumericSorter(Sorter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Sorter.Props):
         expression: Expression | None
         sort_order: SortType
@@ -21448,43 +18925,9 @@ class Overlay(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -21493,6 +18936,7 @@ class Overlay(Widget):
         self,
         *,
         child: Widget | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -21523,7 +18967,6 @@ class Overlay(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_overlay(self, widget: Widget) -> None: ...
     def get_child(self) -> Widget | None: ...
@@ -21574,11 +19017,10 @@ class OverlayLayoutChild(LayoutChild):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(LayoutChild.Props):
         clip_overlay: bool
         measure: bool
-        child_widget: Widget
-        layout_manager: LayoutManager
 
     @property
     def props(self) -> Props: ...
@@ -21656,13 +19098,12 @@ class PadController(EventController):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        action_group: Gio.ActionGroup
-        pad: _Gdk4.Device
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
+        @property
+        def action_group(self) -> Gio.ActionGroup: ...
+        @property
+        def pad(self) -> _Gdk4.Device: ...
 
     @property
     def props(self) -> Props: ...
@@ -21861,76 +19302,16 @@ class PageSetupUnixDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -21986,7 +19367,6 @@ class PageSetupUnixDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_page_setup(self) -> PageSetup: ...
     def get_print_settings(self) -> PrintSettings | None: ...
@@ -22086,10 +19466,13 @@ class Paned(Widget, AccessibleRange, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         end_child: Widget | None
-        max_position: int
-        min_position: int
+        @property
+        def max_position(self) -> int: ...
+        @property
+        def min_position(self) -> int: ...
         position: int
         position_set: bool
         resize_end_child: bool
@@ -22098,41 +19481,6 @@ class Paned(Widget, AccessibleRange, Orientable):
         shrink_start_child: bool
         start_child: Widget | None
         wide_handle: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -22150,6 +19498,8 @@ class Paned(Widget, AccessibleRange, Orientable):
         shrink_start_child: bool = ...,
         start_child: Widget | None = ...,
         wide_handle: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -22180,8 +19530,6 @@ class Paned(Widget, AccessibleRange, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_end_child(self) -> Widget | None: ...
     def get_position(self) -> int: ...
@@ -22348,52 +19696,20 @@ class PasswordEntry(Widget, Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activates_default: bool
         extra_menu: Gio.MenuModel | None
         placeholder_text: str
         show_peek_icon: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -22407,6 +19723,13 @@ class PasswordEntry(Widget, Editable):
         extra_menu: Gio.MenuModel | None = ...,
         placeholder_text: str = ...,
         show_peek_icon: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -22437,13 +19760,6 @@ class PasswordEntry(Widget, Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def get_extra_menu(self) -> Gio.MenuModel | None: ...
     def get_show_peek_icon(self) -> bool: ...
@@ -22475,13 +19791,6 @@ class PasswordEntryBuffer(EntryBuffer):
     Signals from GObject:
       notify (GParam)
     """
-    class Props(EntryBuffer.Props):
-        length: int
-        max_length: int
-        text: str
-
-    @property
-    def props(self) -> Props: ...
     def __init__(self, *, max_length: int = ..., text: str = ...) -> None: ...
     @classmethod
     def new(cls) -> PasswordEntryBuffer: ...
@@ -22578,6 +19887,7 @@ class Picture(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         alternative_text: str | None
         can_shrink: bool
@@ -22585,41 +19895,6 @@ class Picture(Widget):
         file: Gio.File | None
         keep_aspect_ratio: bool
         paintable: _Gdk4.Paintable | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -22633,6 +19908,7 @@ class Picture(Widget):
         file: Gio.File | None = ...,
         keep_aspect_ratio: bool = ...,
         paintable: _Gdk4.Paintable | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -22663,7 +19939,6 @@ class Picture(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_alternative_text(self) -> str | None: ...
     def get_can_shrink(self) -> bool: ...
@@ -22784,6 +20059,7 @@ class Popover(Widget, Native, ShortcutManager):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         autohide: bool
         cascade_popdown: bool
@@ -22791,43 +20067,8 @@ class Popover(Widget, Native, ShortcutManager):
         default_widget: Widget | None
         has_arrow: bool
         mnemonics_visible: bool
-        pointing_to: _Gdk4.Rectangle
+        pointing_to: _Gdk4.Rectangle | None
         position: PositionType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -22845,6 +20086,7 @@ class Popover(Widget, Native, ShortcutManager):
         mnemonics_visible: bool = ...,
         pointing_to: _Gdk4.Rectangle | None = ...,
         position: PositionType = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -22875,7 +20117,6 @@ class Popover(Widget, Native, ShortcutManager):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def do_activate_default(self) -> None: ...
     def do_closed(self) -> None: ...
@@ -23005,53 +20246,11 @@ class PopoverMenu(Popover):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Popover.Props):
         flags: PopoverMenuFlags
         menu_model: Gio.MenuModel | None
         visible_submenu: str
-        autohide: bool
-        cascade_popdown: bool
-        child: Widget | None
-        default_widget: Widget | None
-        has_arrow: bool
-        mnemonics_visible: bool
-        pointing_to: _Gdk4.Rectangle
-        position: PositionType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -23062,6 +20261,7 @@ class PopoverMenu(Popover):
         flags: PopoverMenuFlags = ...,
         menu_model: Gio.MenuModel | None = ...,
         visible_submenu: str = ...,
+        accessible_role: AccessibleRole = ...,
         autohide: bool = ...,
         cascade_popdown: bool = ...,
         child: Widget | None = ...,
@@ -23100,7 +20300,6 @@ class PopoverMenu(Popover):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_child(self, child: Widget, id: str) -> bool: ...
     def get_flags(self) -> PopoverMenuFlags: ...
@@ -23184,43 +20383,9 @@ class PopoverMenuBar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         menu_model: Gio.MenuModel | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -23229,6 +20394,7 @@ class PopoverMenuBar(Widget):
         self,
         *,
         menu_model: Gio.MenuModel | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -23259,7 +20425,6 @@ class PopoverMenuBar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_child(self, child: Widget, id: str) -> bool: ...
     def get_menu_model(self) -> Gio.MenuModel | None: ...
@@ -23318,6 +20483,7 @@ class PrintDialog(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accept_label: str
         modal: bool
@@ -23411,11 +20577,16 @@ class PrintJob(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        page_setup: PageSetup
-        printer: Printer
-        settings: PrintSettings
-        title: str
+        @property
+        def page_setup(self) -> PageSetup: ...
+        @property
+        def printer(self) -> Printer: ...
+        @property
+        def settings(self) -> PrintSettings: ...
+        @property
+        def title(self) -> str: ...
         track_print_status: bool
 
     @property
@@ -23519,21 +20690,25 @@ class PrintOperation(GObject.Object, PrintOperationPreview):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         allow_async: bool
         current_page: int
         custom_tab_label: str | None
-        default_page_setup: PageSetup
+        default_page_setup: PageSetup | None
         embed_page_setup: bool
         export_filename: str
         has_selection: bool
         job_name: str
         n_pages: int
-        n_pages_to_print: int
+        @property
+        def n_pages_to_print(self) -> int: ...
         print_settings: PrintSettings | None
         show_progress: bool
-        status: PrintStatus
-        status_string: str
+        @property
+        def status(self) -> PrintStatus: ...
+        @property
+        def status_string(self) -> str: ...
         support_selection: bool
         track_print_status: bool
         unit: Unit
@@ -23925,78 +21100,18 @@ class PrintUnixDialog(Dialog):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Dialog.Props):
         current_page: int
         embed_page_setup: bool
         has_selection: bool
         manual_capabilities: PrintCapabilities
         page_setup: PageSetup
-        print_settings: PrintSettings
-        selected_printer: Printer | None
+        print_settings: PrintSettings | None
+        @property
+        def selected_printer(self) -> Printer | None: ...
         support_selection: bool
-        use_header_bar: int
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -24010,6 +21125,7 @@ class PrintUnixDialog(Dialog):
         page_setup: PageSetup = ...,
         print_settings: PrintSettings | None = ...,
         support_selection: bool = ...,
+        accessible_role: AccessibleRole = ...,
         use_header_bar: int = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
@@ -24065,7 +21181,6 @@ class PrintUnixDialog(Dialog):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_custom_tab(self, child: Widget, tab_label: Widget) -> None: ...
     def get_current_page(self) -> int: ...
@@ -24119,17 +21234,28 @@ class Printer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        accepting_jobs: bool
-        accepts_pdf: bool
-        accepts_ps: bool
-        icon_name: str
-        is_virtual: bool
-        job_count: int
-        location: str
-        name: str
-        paused: bool
-        state_message: str
+        @property
+        def accepting_jobs(self) -> bool: ...
+        @property
+        def accepts_pdf(self) -> bool: ...
+        @property
+        def accepts_ps(self) -> bool: ...
+        @property
+        def icon_name(self) -> str: ...
+        @property
+        def is_virtual(self) -> bool: ...
+        @property
+        def job_count(self) -> int: ...
+        @property
+        def location(self) -> str: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def paused(self) -> bool: ...
+        @property
+        def state_message(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -24242,6 +21368,7 @@ class ProgressBar(Widget, AccessibleRange, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         ellipsize: Pango.EllipsizeMode
         fraction: float
@@ -24249,41 +21376,6 @@ class ProgressBar(Widget, AccessibleRange, Orientable):
         pulse_step: float
         show_text: bool
         text: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -24298,6 +21390,8 @@ class ProgressBar(Widget, AccessibleRange, Orientable):
         pulse_step: float = ...,
         show_text: bool = ...,
         text: str | None = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -24328,8 +21422,6 @@ class ProgressBar(Widget, AccessibleRange, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_ellipsize(self) -> Pango.EllipsizeMode: ...
     def get_fraction(self) -> float: ...
@@ -24449,6 +21541,7 @@ class Range(Widget, AccessibleRange, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         adjustment: Adjustment
         fill_level: float
@@ -24456,41 +21549,6 @@ class Range(Widget, AccessibleRange, Orientable):
         restrict_to_fill_level: bool
         round_digits: int
         show_fill_level: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -24507,6 +21565,8 @@ class Range(Widget, AccessibleRange, Orientable):
         restrict_to_fill_level: bool = ...,
         round_digits: int = ...,
         show_fill_level: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -24537,8 +21597,6 @@ class Range(Widget, AccessibleRange, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_adjust_bounds(self, new_value: float) -> None: ...
     def do_change_value(self, scroll: ScrollType, new_value: float) -> bool: ...
@@ -24657,9 +21715,12 @@ class RecentManager(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        filename: str
-        size: int
+        @property
+        def filename(self) -> str: ...
+        @property
+        def size(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -24802,47 +21863,14 @@ class Revealer(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
-        child_revealed: bool
+        @property
+        def child_revealed(self) -> bool: ...
         reveal_child: bool
         transition_duration: int
         transition_type: RevealerTransitionType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -24854,6 +21882,7 @@ class Revealer(Widget):
         reveal_child: bool = ...,
         transition_duration: int = ...,
         transition_type: RevealerTransitionType = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -24884,7 +21913,6 @@ class Revealer(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     def get_child_revealed(self) -> bool: ...
@@ -24998,52 +22026,12 @@ class Scale(Range):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Range.Props):
         digits: int
         draw_value: bool
         has_origin: bool
         value_pos: PositionType
-        adjustment: Adjustment
-        fill_level: float
-        inverted: bool
-        restrict_to_fill_level: bool
-        round_digits: int
-        show_fill_level: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -25058,6 +22046,8 @@ class Scale(Range):
         draw_value: bool = ...,
         has_origin: bool = ...,
         value_pos: PositionType = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         fill_level: float = ...,
         inverted: bool = ...,
@@ -25094,8 +22084,6 @@ class Scale(Range):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_mark(
         self, value: float, position: PositionType, markup: str | None = None
@@ -25202,47 +22190,14 @@ class ScaleButton(Widget, AccessibleRange, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        active: bool
+        @property
+        def active(self) -> bool: ...
         adjustment: Adjustment
         has_frame: bool
         icons: list[str]
         value: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -25257,6 +22212,8 @@ class ScaleButton(Widget, AccessibleRange, Orientable):
         has_frame: bool = ...,
         icons: Sequence[str] = ...,
         value: float = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -25287,8 +22244,6 @@ class ScaleButton(Widget, AccessibleRange, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def do_value_changed(self, value: float) -> None: ...
     def get_active(self) -> bool: ...
@@ -25455,43 +22410,9 @@ class Scrollbar(Widget, AccessibleRange, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        adjustment: Adjustment
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        adjustment: Adjustment | None
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -25501,6 +22422,8 @@ class Scrollbar(Widget, AccessibleRange, Orientable):
         self,
         *,
         adjustment: Adjustment | None = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -25531,8 +22454,6 @@ class Scrollbar(Widget, AccessibleRange, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_adjustment(self) -> Adjustment: ...
     @classmethod
@@ -25630,9 +22551,10 @@ class ScrolledWindow(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
-        hadjustment: Adjustment
+        hadjustment: Adjustment | None
         has_frame: bool
         hscrollbar_policy: PolicyType
         kinetic_scrolling: bool
@@ -25643,44 +22565,9 @@ class ScrolledWindow(Widget):
         overlay_scrolling: bool
         propagate_natural_height: bool
         propagate_natural_width: bool
-        vadjustment: Adjustment
+        vadjustment: Adjustment | None
         vscrollbar_policy: PolicyType
         window_placement: CornerType
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -25703,6 +22590,7 @@ class ScrolledWindow(Widget):
         vadjustment: Adjustment | None = ...,
         vscrollbar_policy: PolicyType = ...,
         window_placement: CornerType = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -25733,7 +22621,6 @@ class ScrolledWindow(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     def get_hadjustment(self) -> Adjustment: ...
@@ -25843,46 +22730,12 @@ class SearchBar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
         key_capture_widget: Widget | None
         search_mode_enabled: bool
         show_close_button: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -25894,6 +22747,7 @@ class SearchBar(Widget):
         key_capture_widget: Widget | None = ...,
         search_mode_enabled: bool = ...,
         show_close_button: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -25924,7 +22778,6 @@ class SearchBar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def connect_entry(self, entry: Editable) -> None: ...
     def get_child(self) -> Widget | None: ...
@@ -26024,53 +22877,21 @@ class SearchEntry(Widget, Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activates_default: bool
         input_hints: InputHints
         input_purpose: InputPurpose
         placeholder_text: str | None
         search_delay: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -26085,6 +22906,13 @@ class SearchEntry(Widget, Editable):
         input_purpose: InputPurpose = ...,
         placeholder_text: str | None = ...,
         search_delay: int = ...,
+        accessible_role: AccessibleRole = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -26115,13 +22943,6 @@ class SearchEntry(Widget, Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def get_input_hints(self) -> InputHints: ...
     def get_input_purpose(self) -> InputPurpose: ...
@@ -26181,10 +23002,13 @@ class SelectionFilterModel(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: SelectionModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -26323,42 +23147,8 @@ class Separator(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -26367,6 +23157,8 @@ class Separator(Widget, Orientable):
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -26397,8 +23189,6 @@ class Separator(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls, orientation: Orientation) -> Separator: ...
@@ -26475,6 +23265,7 @@ class Settings(GObject.Object, StyleProvider):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         gtk_alternative_button_order: bool
         gtk_alternative_sort_arrows: bool
@@ -26616,6 +23407,7 @@ class Shortcut(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         action: ShortcutAction | None
         arguments: GLib.Variant | None
@@ -26712,16 +23504,14 @@ class ShortcutController(EventController, Gio.ListModel, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(EventController.Props):
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         mnemonic_modifiers: _Gdk4.ModifierType
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
         scope: ShortcutScope
-        name: str | None
-        propagation_limit: PropagationLimit
-        propagation_phase: PropagationPhase
-        widget: Widget | None
-        model: Gio.ListModel
 
     @property
     def props(self) -> Props: ...
@@ -26818,44 +23608,10 @@ class ShortcutLabel(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         accelerator: str | None
         disabled_text: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -26865,6 +23621,7 @@ class ShortcutLabel(Widget):
         *,
         accelerator: str = ...,
         disabled_text: str = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -26895,7 +23652,6 @@ class ShortcutLabel(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_accelerator(self) -> str | None: ...
     def get_disabled_text(self) -> str | None: ...
@@ -26905,7 +23661,14 @@ class ShortcutLabel(Widget):
     def set_disabled_text(self, disabled_text: str) -> None: ...
 
 class ShortcutLabelClass(_gi.Struct): ...
-class ShortcutManager(GObject.GInterface, Protocol): ...
+
+class ShortcutManager(GObject.GInterface, Protocol):
+    """
+    Interface GtkShortcutManager
+
+    Signals from GObject:
+      notify (GParam)
+    """
 
 class ShortcutManagerInterface(_gi.Struct):
     """
@@ -27031,53 +23794,16 @@ class ShortcutsGroup(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
-        height: int
+        accel_size_group: SizeGroup
+        @property
+        def height(self) -> int: ...
         title: str
+        title_size_group: SizeGroup
         view: str
-        baseline_child: int
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
-        accel_size_group: SizeGroup
-        title_size_group: SizeGroup
 
     @property
     def props(self) -> Props: ...
@@ -27088,6 +23814,8 @@ class ShortcutsGroup(Box):
         title: str = ...,
         title_size_group: SizeGroup = ...,
         view: str = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         baseline_child: int = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
@@ -27122,8 +23850,6 @@ class ShortcutsGroup(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_shortcut(self, shortcut: ShortcutsShortcut) -> None: ...
 
@@ -27209,50 +23935,12 @@ class ShortcutsSection(Box):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Box.Props):
         max_height: int
         section_name: str
         title: str
         view_name: str
-        baseline_child: int
-        baseline_position: BaselinePosition
-        homogeneous: bool
-        spacing: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -27265,6 +23953,8 @@ class ShortcutsSection(Box):
         section_name: str = ...,
         title: str = ...,
         view_name: str = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         baseline_child: int = ...,
         baseline_position: BaselinePosition = ...,
         homogeneous: bool = ...,
@@ -27299,8 +23989,6 @@ class ShortcutsSection(Box):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def add_group(self, group: ShortcutsGroup) -> None: ...
 
@@ -27384,7 +24072,9 @@ class ShortcutsShortcut(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
+        accel_size_group: SizeGroup
         accelerator: str
         action_name: str
         direction: TextDirection
@@ -27394,44 +24084,8 @@ class ShortcutsShortcut(Widget):
         subtitle: str
         subtitle_set: bool
         title: str
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
-        accessible_role: AccessibleRole
-        accel_size_group: SizeGroup
         title_size_group: SizeGroup
+        accessible_role: AccessibleRole
 
     @property
     def props(self) -> Props: ...
@@ -27449,6 +24103,7 @@ class ShortcutsShortcut(Widget):
         subtitle_set: bool = ...,
         title: str = ...,
         title_size_group: SizeGroup = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -27479,7 +24134,6 @@ class ShortcutsShortcut(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
 
 class ShortcutsShortcutClass(_gi.Struct): ...
@@ -27592,71 +24246,11 @@ class ShortcutsWindow(Window):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Window.Props):
         section_name: str
         view_name: str
-        application: Application | None
-        child: Widget | None
-        decorated: bool
-        default_height: int
-        default_widget: Widget | None
-        default_width: int
-        deletable: bool
-        destroy_with_parent: bool
-        display: _Gdk4.Display
-        focus_visible: bool
-        focus_widget: Widget | None
-        fullscreened: bool
-        gravity: WindowGravity
-        handle_menubar_accel: bool
-        hide_on_close: bool
-        icon_name: str | None
-        is_active: bool
-        maximized: bool
-        mnemonics_visible: bool
-        modal: bool
-        resizable: bool
-        suspended: bool
-        title: str | None
-        titlebar: Widget | None
-        transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -27665,6 +24259,7 @@ class ShortcutsWindow(Window):
         *,
         section_name: str = ...,
         view_name: str = ...,
+        accessible_role: AccessibleRole = ...,
         application: Application | None = ...,
         child: Widget | None = ...,
         decorated: bool = ...,
@@ -27719,7 +24314,6 @@ class ShortcutsWindow(Window):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_section(self, section: ShortcutsSection) -> None: ...
 
@@ -27740,8 +24334,10 @@ class SignalAction(ShortcutAction):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ShortcutAction.Props):
-        signal_name: str
+        @property
+        def signal_name(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -27809,14 +24405,18 @@ class SingleSelection(GObject.Object, Gio.ListModel, SectionModel, SelectionMode
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         autoselect: bool
         can_unselect: bool
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
         selected: int
-        selected_item: GObject.Object | None
+        @property
+        def selected_item(self) -> GObject.Object | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -27868,6 +24468,7 @@ class SizeGroup(GObject.Object, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         mode: SizeGroupMode
 
@@ -27911,10 +24512,13 @@ class SliceListModel(GObject.Object, Gio.ListModel, SectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
+        @property
+        def n_items(self) -> int: ...
         offset: int
         size: int
 
@@ -28136,12 +24740,16 @@ class SortListModel(GObject.Object, Gio.ListModel, SectionModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         incremental: bool
-        item_type: type[Any]
+        @property
+        def item_type(self) -> type[Any]: ...
         model: Gio.ListModel | None
-        n_items: int
-        pending: int
+        @property
+        def n_items(self) -> int: ...
+        @property
+        def pending(self) -> int: ...
         section_sorter: Sorter | None
         sorter: Sorter | None
 
@@ -28318,6 +24926,7 @@ class SpinButton(Widget, AccessibleRange, CellEditable, Editable, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activates_default: bool
         adjustment: Adjustment
@@ -28328,48 +24937,15 @@ class SpinButton(Widget, AccessibleRange, CellEditable, Editable, Orientable):
         update_policy: SpinButtonUpdatePolicy
         value: float
         wrap: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         editing_canceled: bool
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -28389,6 +24965,15 @@ class SpinButton(Widget, AccessibleRange, CellEditable, Editable, Orientable):
         update_policy: SpinButtonUpdatePolicy = ...,
         value: float = ...,
         wrap: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        editing_canceled: bool = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -28419,15 +25004,6 @@ class SpinButton(Widget, AccessibleRange, CellEditable, Editable, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editing_canceled: bool = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def configure(
         self, adjustment: Adjustment | None, climb_rate: float, digits: int
@@ -28533,43 +25109,9 @@ class Spinner(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         spinning: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -28578,6 +25120,7 @@ class Spinner(Widget):
         self,
         *,
         spinning: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -28608,7 +25151,6 @@ class Spinner(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_spinning(self) -> bool: ...
     @classmethod
@@ -28694,51 +25236,19 @@ class Stack(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         hhomogeneous: bool
         interpolate_size: bool
-        pages: SelectionModel
+        @property
+        def pages(self) -> SelectionModel: ...
         transition_duration: int
-        transition_running: bool
+        @property
+        def transition_running(self) -> bool: ...
         transition_type: StackTransitionType
         vhomogeneous: bool
         visible_child: Widget | None
         visible_child_name: str | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -28753,6 +25263,7 @@ class Stack(Widget):
         vhomogeneous: bool = ...,
         visible_child: Widget = ...,
         visible_child_name: str = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -28783,7 +25294,6 @@ class Stack(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def add_child(self, child: Widget) -> StackPage: ...
     def add_named(self, child: Widget, name: str | None = None) -> StackPage: ...
@@ -28835,8 +25345,10 @@ class StackPage(GObject.Object, Accessible):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child: Widget
+        @property
+        def child(self) -> Widget: ...
         icon_name: str | None
         name: str | None
         needs_attention: bool
@@ -28942,43 +25454,9 @@ class StackSidebar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         stack: Stack | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -28987,6 +25465,7 @@ class StackSidebar(Widget):
         self,
         *,
         stack: Stack = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -29017,7 +25496,6 @@ class StackSidebar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_stack(self) -> Stack | None: ...
     @classmethod
@@ -29093,43 +25571,9 @@ class StackSwitcher(Widget, Orientable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         stack: Stack | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -29139,6 +25583,8 @@ class StackSwitcher(Widget, Orientable):
         self,
         *,
         stack: Stack | None = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -29169,8 +25615,6 @@ class StackSwitcher(Widget, Orientable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     def get_stack(self) -> Stack | None: ...
     @classmethod
@@ -29247,42 +25691,8 @@ class Statusbar(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -29290,6 +25700,7 @@ class Statusbar(Widget):
     def __init__(
         self,
         *,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -29320,7 +25731,6 @@ class Statusbar(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_context_id(self, context_description: str) -> int: ...
     @classmethod
@@ -29353,6 +25763,7 @@ class StringFilter(Filter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Filter.Props):
         expression: Expression | None
         ignore_case: bool
@@ -29413,10 +25824,12 @@ class StringList(GObject.Object, Gio.ListModel, Buildable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        item_type: type[Any]
-        n_items: int
-        strings: list[str]
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def n_items(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
@@ -29460,8 +25873,10 @@ class StringObject(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        string: str
+        @property
+        def string(self) -> str: ...
 
     @property
     def props(self) -> Props: ...
@@ -29502,6 +25917,7 @@ class StringSorter(Sorter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Sorter.Props):
         collation: Collation
         expression: Expression | None
@@ -29552,6 +25968,7 @@ class StyleContext(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         display: _Gdk4.Display
 
@@ -29602,7 +26019,13 @@ class StyleContextClass(_gi.Struct):
     @property
     def changed(self) -> Callable[[StyleContext], None]: ...
 
-class StyleProvider(GObject.GInterface, Protocol): ...
+class StyleProvider(GObject.GInterface, Protocol):
+    """
+    Interface GtkStyleProvider
+
+    Signals from GObject:
+      notify (GParam)
+    """
 
 class Switch(Widget, Actionable):
     """
@@ -29678,44 +26101,10 @@ class Switch(Widget, Actionable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         active: bool
         state: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
@@ -29727,6 +26116,9 @@ class Switch(Widget, Actionable):
         *,
         active: bool = ...,
         state: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -29757,9 +26149,6 @@ class Switch(Widget, Actionable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def get_active(self) -> bool: ...
     def get_state(self) -> bool: ...
@@ -29907,6 +26296,7 @@ class Text(Widget, AccessibleText, Editable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activates_default: bool
         attributes: Pango.AttrList | None
@@ -29922,51 +26312,19 @@ class Text(Widget, AccessibleText, Editable):
         overwrite_mode: bool
         placeholder_text: str | None
         propagate_text_width: bool
-        scroll_offset: int
+        @property
+        def scroll_offset(self) -> int: ...
         tabs: Pango.TabArray | None
         truncate_multiline: bool
         visibility: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        cursor_position: int
+        @property
+        def cursor_position(self) -> int: ...
         editable: bool
         enable_undo: bool
         max_width_chars: int
-        selection_bound: int
+        @property
+        def selection_bound(self) -> int: ...
         text: str
         width_chars: int
         xalign: float
@@ -29995,6 +26353,13 @@ class Text(Widget, AccessibleText, Editable):
         tabs: Pango.TabArray | None = ...,
         truncate_multiline: bool = ...,
         visibility: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        editable: bool = ...,
+        enable_undo: bool = ...,
+        max_width_chars: int = ...,
+        text: str = ...,
+        width_chars: int = ...,
+        xalign: float = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -30025,13 +26390,6 @@ class Text(Widget, AccessibleText, Editable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        editable: bool = ...,
-        enable_undo: bool = ...,
-        max_width_chars: int = ...,
-        text: str = ...,
-        width_chars: int = ...,
-        xalign: float = ...,
     ) -> None: ...
     def compute_cursor_extents(
         self, position: int
@@ -30114,13 +26472,19 @@ class TextBuffer(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        can_redo: bool
-        can_undo: bool
-        cursor_position: int
+        @property
+        def can_redo(self) -> bool: ...
+        @property
+        def can_undo(self) -> bool: ...
+        @property
+        def cursor_position(self) -> int: ...
         enable_undo: bool
-        has_selection: bool
-        tag_table: TextTagTable
+        @property
+        def has_selection(self) -> bool: ...
+        @property
+        def tag_table(self) -> TextTagTable: ...
         text: str
 
     @property
@@ -30513,9 +26877,12 @@ class TextMark(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        left_gravity: bool
-        name: str | None
+        @property
+        def left_gravity(self) -> bool: ...
+        @property
+        def name(self) -> str | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -30651,10 +27018,12 @@ class TextTag(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         accumulative_margin: bool
         allow_breaks: bool
         allow_breaks_set: bool
+        background: str
         background_full_height: bool
         background_full_height_set: bool
         background_rgba: _Gdk4.RGBA
@@ -30670,6 +27039,7 @@ class TextTag(GObject.Object):
         font_desc: Pango.FontDescription
         font_features: str
         font_features_set: bool
+        foreground: str
         foreground_rgba: _Gdk4.RGBA
         foreground_set: bool
         indent: int
@@ -30688,11 +27058,13 @@ class TextTag(GObject.Object):
         letter_spacing_set: bool
         line_height: float
         line_height_set: bool
-        name: str
+        @property
+        def name(self) -> str: ...
         overline: Pango.Overline
         overline_rgba: _Gdk4.RGBA
         overline_rgba_set: bool
         overline_set: bool
+        paragraph_background: str
         paragraph_background_rgba: _Gdk4.RGBA
         paragraph_background_set: bool
         pixels_above_lines: int
@@ -30738,9 +27110,6 @@ class TextTag(GObject.Object):
         word_set: bool
         wrap_mode: WrapMode
         wrap_mode_set: bool
-        background: str
-        foreground: str
-        paragraph_background: str
 
     @property
     def props(self) -> Props: ...
@@ -30996,13 +27365,14 @@ class TextView(Widget, AccessibleText, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         accepts_tab: bool
         bottom_margin: int
-        buffer: TextBuffer
+        buffer: TextBuffer | None
         cursor_visible: bool
         editable: bool
-        extra_menu: Gio.MenuModel
+        extra_menu: Gio.MenuModel | None
         im_module: str
         indent: int
         input_hints: InputHints
@@ -31018,41 +27388,6 @@ class TextView(Widget, AccessibleText, Scrollable):
         tabs: Pango.TabArray | None
         top_margin: int
         wrap_mode: WrapMode
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
@@ -31089,6 +27424,11 @@ class TextView(Widget, AccessibleText, Scrollable):
         tabs: Pango.TabArray = ...,
         top_margin: int = ...,
         wrap_mode: WrapMode = ...,
+        accessible_role: AccessibleRole = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -31119,11 +27459,6 @@ class TextView(Widget, AccessibleText, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def add_child_at_anchor(self, child: Widget, anchor: TextChildAnchor) -> None: ...
     def add_overlay(self, child: Widget, xpos: int, ypos: int) -> None: ...
@@ -31374,53 +27709,13 @@ class ToggleButton(Button):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Button.Props):
         active: bool
-        can_shrink: bool
-        child: Widget | None
-        has_frame: bool
-        icon_name: str | None
-        label: str | None
-        use_underline: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
+        group: ToggleButton | None
         accessible_role: AccessibleRole
         action_name: str | None
         action_target: GLib.Variant
-        group: ToggleButton | None
 
     @property
     def props(self) -> Props: ...
@@ -31431,6 +27726,9 @@ class ToggleButton(Button):
         *,
         active: bool = ...,
         group: ToggleButton | None = ...,
+        accessible_role: AccessibleRole = ...,
+        action_name: str | None = ...,
+        action_target: GLib.Variant = ...,
         can_shrink: bool = ...,
         child: Widget | None = ...,
         has_frame: bool = ...,
@@ -31467,9 +27765,6 @@ class ToggleButton(Button):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        action_name: str | None = ...,
-        action_target: GLib.Variant = ...,
     ) -> None: ...
     def do_toggled(self) -> None: ...
     def get_active(self) -> bool: ...
@@ -31642,48 +27937,15 @@ class TreeExpander(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
         hide_expander: bool
         indent_for_depth: bool
         indent_for_icon: bool
-        item: GObject.Object | None
+        @property
+        def item(self) -> GObject.Object | None: ...
         list_row: TreeListRow | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -31696,6 +27958,7 @@ class TreeExpander(Widget):
         indent_for_depth: bool = ...,
         indent_for_icon: bool = ...,
         list_row: TreeListRow | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -31726,7 +27989,6 @@ class TreeExpander(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     def get_hide_expander(self) -> bool: ...
@@ -31793,12 +28055,17 @@ class TreeListModel(GObject.Object, Gio.ListModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         autoexpand: bool
-        item_type: type[Any]
-        model: Gio.ListModel
-        n_items: int
-        passthrough: bool
+        @property
+        def item_type(self) -> type[Any]: ...
+        @property
+        def model(self) -> Gio.ListModel: ...
+        @property
+        def n_items(self) -> int: ...
+        @property
+        def passthrough(self) -> bool: ...
 
     @property
     def props(self) -> Props: ...
@@ -31850,12 +28117,17 @@ class TreeListRow(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        children: Gio.ListModel | None
-        depth: int
-        expandable: bool
+        @property
+        def children(self) -> Gio.ListModel | None: ...
+        @property
+        def depth(self) -> int: ...
+        @property
+        def expandable(self) -> bool: ...
         expanded: bool
-        item: GObject.Object | None
+        @property
+        def item(self) -> GObject.Object | None: ...
 
     @property
     def props(self) -> Props: ...
@@ -31901,6 +28173,7 @@ class TreeListRowSorter(Sorter):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Sorter.Props):
         sorter: Sorter | None
 
@@ -31991,9 +28264,12 @@ class TreeModelFilter(GObject.Object, TreeDragSource, TreeModel):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        child_model: TreeModel
-        virtual_root: TreePath
+        @property
+        def child_model(self) -> TreeModel: ...
+        @property
+        def virtual_root(self) -> TreePath: ...
 
     @property
     def props(self) -> Props: ...
@@ -32111,25 +28387,41 @@ class TreeModelIface(_gi.Struct):
     @property
     def unref_node(self) -> Callable[[TreeModel, TreeIter], None]: ...
 
-# override
 class TreeModelRow:
-    iter: TreeIter
-    model: TreeModel
-    next = ...
-    parent = ...
-    path = ...
-    previous = ...
+    # override
+    def __init__(self, model: TreeModel, iter_or_path: TreeIter | TreePath) -> None: ...
+    # override
+    @property
+    def next(self) -> TreeModelRow | None: ...
+    # override
+    @property
+    def parent(self) -> TreeModelRow | None: ...
+    # override
+    @property
+    def path(self) -> TreePath: ...
+    # override
+    @property
+    def previous(self) -> TreeModelRow | None: ...
 
-    def get_next(self): ...
-    def get_parent(self): ...
-    def get_previous(self): ...
-    def iterchildren(self) -> Iterator[TreeModelRow]: ...
+    # override
     def __getitem__(self, key: int) -> Any: ...
+    # override
     def __setitem__(self, key: int, value: Any) -> None: ...
+    # override
+    def get_next(self) -> TreeModelRow | None: ...
+    # override
+    def get_parent(self) -> TreeModelRow | None: ...
+    # override
+    def get_previous(self) -> TreeModelRow | None: ...
+    # override
+    def iterchildren(self) -> Iterator[TreeModelRow]: ...
 
-# override
 class TreeModelRowIter:
-    def next(self) -> TreeModelRow: ...
+    # override
+    def __init__(self, model: TreeModelRow, aiter: TreeModelRowIter | None) -> None: ...
+    # override
+    def __iter__(self) -> Self: ...
+    # override
     def __next__(self) -> TreeModelRow: ...
 
 class TreeModelSort(GObject.Object, TreeDragSource, TreeModel, TreeSortable):
@@ -32159,8 +28451,10 @@ class TreeModelSort(GObject.Object, TreeDragSource, TreeModel, TreeSortable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
-        model: TreeModel
+        @property
+        def model(self) -> TreeModel: ...
 
     @property
     def props(self) -> Props: ...
@@ -32238,18 +28532,17 @@ class TreePath(GObject.GBoxed):
 
 class TreeRowData(GObject.GBoxed): ...
 
-# override
 class TreeRowReference(GObject.GBoxed):
     """
     :Constructors:
 
     ::
 
-        new(model:TreeModel, path:TreePath) -> TreeRowReference or None
-        new_proxy(proxy:GObject.Object, model:TreeModel, path:TreePath) -> TreeRowReference or None
+        new(model:Gtk.TreeModel, path:Gtk.TreePath) -> Gtk.TreeRowReference or None
+        new_proxy(proxy:GObject.Object, model:Gtk.TreeModel, path:Gtk.TreePath) -> Gtk.TreeRowReference or None
     """
-
-    def __init__(self, model: TreeModel, path: TreePath) -> None: ...
+    @staticmethod
+    def __new__(cls: type[Self], model: TreeModel, path: TreePath) -> Self: ...
     def copy(self) -> TreeRowReference: ...
     @staticmethod
     def deleted(proxy: GObject.Object, path: TreePath) -> None: ...
@@ -32285,6 +28578,7 @@ class TreeSelection(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         mode: SelectionMode
 
@@ -32364,7 +28658,6 @@ class TreeSortableIface(_gi.Struct):
     @property
     def has_default_sort_func(self) -> Callable[[TreeSortable], bool]: ...
 
-# override
 class TreeStore(
     GObject.Object, Buildable, TreeDragDest, TreeDragSource, TreeModel, TreeSortable
 ):
@@ -32374,36 +28667,41 @@ class TreeStore(
     ::
 
         TreeStore(**properties)
-        new(types:list) -> TreeStore
+        new(types:list) -> Gtk.TreeStore
 
     Object GtkTreeStore
 
     Signals from GtkTreeModel:
-      rowchanged (GtkTreePath, GtkTreeIter)
-      rowinserted (GtkTreePath, GtkTreeIter)
-      rowhaschildtoggled (GtkTreePath, GtkTreeIter)
-      rowdeleted (GtkTreePath)
-      rowsreordered (GtkTreePath, GtkTreeIter, gpointer)
+      row-changed (GtkTreePath, GtkTreeIter)
+      row-inserted (GtkTreePath, GtkTreeIter)
+      row-has-child-toggled (GtkTreePath, GtkTreeIter)
+      row-deleted (GtkTreePath)
+      rows-reordered (GtkTreePath, GtkTreeIter, gpointer)
 
     Signals from GtkTreeSortable:
-      sortcolumnchanged ()
+      sort-column-changed ()
 
     Signals from GObject:
       notify (GParam)
     """
-
-    parent: GObject.Object = ...
-
+    @property
+    def parent(self) -> GObject.Object: ...
     @property
     def priv(self) -> TreeStorePrivate: ...
-    def __init__(self, *column_types: Any) -> None: ...
+    # override
     def append(
         self, parent: TreeIter | None, row: list[Any] | None = None
     ) -> TreeIter: ...
     def clear(self) -> None: ...
-    def insert(self, parent, position, row=None): ...
-    def insert_after(self, parent, sibling, row=None): ...
-    def insert_before(self, parent, sibling, row=None): ...
+    def insert(
+        self, parent, position, row=None
+    ): ...  # FIXME: Override is missing typing annotation
+    def insert_after(
+        self, parent, sibling, row=None
+    ): ...  # FIXME: Override is missing typing annotation
+    def insert_before(
+        self, parent, sibling, row=None
+    ): ...  # FIXME: Override is missing typing annotation
     def insert_with_values(
         self,
         parent: TreeIter | None,
@@ -32418,11 +28716,15 @@ class TreeStore(
     def move_before(self, iter: TreeIter, position: TreeIter | None = None) -> None: ...
     @classmethod
     def new(cls, types: Sequence[type[Any]]) -> TreeStore: ...
-    def prepend(self, parent, row=None): ...
+    def prepend(
+        self, parent, row=None
+    ): ...  # FIXME: Override is missing typing annotation
     def remove(self, iter: TreeIter) -> bool: ...
-    def set(self, treeiter, *args): ...
+    def set(self, treeiter, *args): ...  # FIXME: Override is missing typing annotation
     def set_column_types(self, types: Sequence[type[Any]]) -> None: ...
-    def set_value(self, treeiter, column, value): ...
+    def set_value(
+        self, treeiter, column, value
+    ): ...  # FIXME: Override is missing typing annotation
     def swap(self, a: TreeIter, b: TreeIter) -> None: ...
 
 class TreeStoreClass(_gi.Struct):
@@ -32543,6 +28845,7 @@ class TreeView(Widget, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         activate_on_single_click: bool
         enable_grid_lines: TreeViewGridLines
@@ -32561,41 +28864,6 @@ class TreeView(Widget, Scrollable):
         search_column: int
         show_expanders: bool
         tooltip_column: int
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
@@ -32626,6 +28894,11 @@ class TreeView(Widget, Scrollable):
         search_column: int = ...,
         show_expanders: bool = ...,
         tooltip_column: int = ...,
+        accessible_role: AccessibleRole = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -32656,11 +28929,6 @@ class TreeView(Widget, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def append_column(self, column: TreeViewColumn) -> int: ...
     def collapse_all(self) -> None: ...
@@ -32900,7 +29168,6 @@ class TreeViewClass(_gi.Struct):
     @property
     def start_interactive_search(self) -> Callable[[TreeView], bool]: ...
 
-# override
 class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
     """
     :Constructors:
@@ -32908,8 +29175,8 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
     ::
 
         TreeViewColumn(**properties)
-        new() -> TreeViewColumn
-        new_with_area(area:CellArea) -> TreeViewColumn
+        new() -> Gtk.TreeViewColumn
+        new_with_area(area:Gtk.CellArea) -> Gtk.TreeViewColumn
 
     Object GtkTreeViewColumn
 
@@ -32919,31 +29186,32 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
     Properties from GtkTreeViewColumn:
       visible -> gboolean: visible
       resizable -> gboolean: resizable
-      xoffset -> gint: xoffset
+      x-offset -> gint: x-offset
       width -> gint: width
       spacing -> gint: spacing
       sizing -> GtkTreeViewColumnSizing: sizing
-      fixedwidth -> gint: fixedwidth
-      minwidth -> gint: minwidth
-      maxwidth -> gint: maxwidth
+      fixed-width -> gint: fixed-width
+      min-width -> gint: min-width
+      max-width -> gint: max-width
       title -> gchararray: title
       expand -> gboolean: expand
       clickable -> gboolean: clickable
       widget -> GtkWidget: widget
       alignment -> gfloat: alignment
       reorderable -> gboolean: reorderable
-      sortindicator -> gboolean: sortindicator
-      sortorder -> GtkSortType: sortorder
-      sortcolumnid -> gint: sortcolumnid
-      cellarea -> GtkCellArea: cellarea
+      sort-indicator -> gboolean: sort-indicator
+      sort-order -> GtkSortType: sort-order
+      sort-column-id -> gint: sort-column-id
+      cell-area -> GtkCellArea: cell-area
 
     Signals from GObject:
       notify (GParam)
     """
-
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         alignment: float
-        cell_area: CellArea
+        @property
+        def cell_area(self) -> CellArea: ...
         clickable: bool
         expand: bool
         fixed_width: int
@@ -32959,20 +29227,38 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
         title: str
         visible: bool
         widget: Widget | None
-        width: int
-        x_offset: int
+        @property
+        def width(self) -> int: ...
+        @property
+        def x_offset(self) -> int: ...
 
     @property
     def props(self) -> Props: ...
     def __init__(
         self,
+        *,
+        alignment: float = ...,
+        cell_area: CellArea = ...,
+        clickable: bool = ...,
+        expand: bool = ...,
+        fixed_width: int = ...,
+        max_width: int = ...,
+        min_width: int = ...,
+        reorderable: bool = ...,
+        resizable: bool = ...,
+        sizing: TreeViewColumnSizing = ...,
+        sort_column_id: int = ...,
+        sort_indicator: bool = ...,
+        sort_order: SortType = ...,
+        spacing: int = ...,
         title: str = ...,
-        cell_renderer: CellRenderer | None = None,
-        **attributes: Any,
+        visible: bool = ...,
+        widget: Widget | None = ...,
     ) -> None: ...
     def add_attribute(
         self, cell_renderer: CellRenderer, attribute: str, column: int
     ) -> None: ...
+    # override
     def cell_get_position(
         self, cell_renderer: CellRenderer
     ) -> tuple[int, int] | None: ...
@@ -33017,9 +29303,11 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
     def pack_start(self, cell: CellRenderer, expand: bool) -> None: ...
     def queue_resize(self) -> None: ...
     def set_alignment(self, xalign: float) -> None: ...
+    # override
     def set_attributes(
         self, cell_renderer: CellRenderer, **attributes: Any
     ) -> None: ...
+    # override
     def set_cell_data_func(
         self,
         cell_renderer: CellRendererT,
@@ -33059,6 +29347,7 @@ class UriLauncher(GObject.Object):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         uri: str | None
 
@@ -33167,47 +29456,13 @@ class Video(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         autoplay: bool
         file: Gio.File | None
         graphics_offload: GraphicsOffloadEnabled
         loop: bool
         media_stream: MediaStream | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -33220,6 +29475,7 @@ class Video(Widget):
         graphics_offload: GraphicsOffloadEnabled = ...,
         loop: bool = ...,
         media_stream: MediaStream | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -33250,7 +29506,6 @@ class Video(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_autoplay(self) -> bool: ...
     def get_file(self) -> Gio.File | None: ...
@@ -33356,44 +29611,10 @@ class Viewport(Widget, Scrollable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
         scroll_to_focus: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         hadjustment: Adjustment | None
         hscroll_policy: ScrollablePolicy
@@ -33407,6 +29628,11 @@ class Viewport(Widget, Scrollable):
         *,
         child: Widget | None = ...,
         scroll_to_focus: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        hadjustment: Adjustment | None = ...,
+        hscroll_policy: ScrollablePolicy = ...,
+        vadjustment: Adjustment | None = ...,
+        vscroll_policy: ScrollablePolicy = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -33437,11 +29663,6 @@ class Viewport(Widget, Scrollable):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        hadjustment: Adjustment | None = ...,
-        hscroll_policy: ScrollablePolicy = ...,
-        vadjustment: Adjustment | None = ...,
-        vscroll_policy: ScrollablePolicy = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     def get_scroll_to_focus(self) -> bool: ...
@@ -33538,48 +29759,9 @@ class VolumeButton(ScaleButton):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(ScaleButton.Props):
         use_symbolic: bool
-        active: bool
-        adjustment: Adjustment
-        has_frame: bool
-        icons: list[str]
-        value: float
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
         orientation: Orientation
 
@@ -33591,6 +29773,8 @@ class VolumeButton(ScaleButton):
         self,
         *,
         use_symbolic: bool = ...,
+        accessible_role: AccessibleRole = ...,
+        orientation: Orientation = ...,
         adjustment: Adjustment = ...,
         has_frame: bool = ...,
         icons: Sequence[str] = ...,
@@ -33625,8 +29809,6 @@ class VolumeButton(ScaleButton):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
-        orientation: Orientation = ...,
     ) -> None: ...
     @classmethod
     def new(cls) -> VolumeButton: ...
@@ -33696,17 +29878,21 @@ class Widget(GObject.InitiallyUnowned, Accessible, Buildable, ConstraintTarget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.InitiallyUnowned.Props):
         can_focus: bool
         can_target: bool
         css_classes: list[str]
-        css_name: str
+        @property
+        def css_name(self) -> str: ...
         cursor: _Gdk4.Cursor | None
         focus_on_click: bool
         focusable: bool
         halign: Align
-        has_default: bool
-        has_focus: bool
+        @property
+        def has_default(self) -> bool: ...
+        @property
+        def has_focus(self) -> bool: ...
         has_tooltip: bool
         height_request: int
         hexpand: bool
@@ -33720,10 +29906,13 @@ class Widget(GObject.InitiallyUnowned, Accessible, Buildable, ConstraintTarget):
         name: str
         opacity: float
         overflow: Overflow
-        parent: Widget | None
+        @property
+        def parent(self) -> Widget | None: ...
         receives_default: bool
-        root: Root | None
-        scale_factor: int
+        @property
+        def root(self) -> Root | None: ...
+        @property
+        def scale_factor(self) -> int: ...
         sensitive: bool
         tooltip_markup: str | None
         tooltip_text: str | None
@@ -34187,6 +30376,7 @@ class WidgetPaintable(GObject.Object, _Gdk4.Paintable):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(GObject.Object.Props):
         widget: Widget | None
 
@@ -34312,6 +30502,7 @@ class Window(Widget, Native, Root, ShortcutManager):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         application: Application | None
         child: Widget | None
@@ -34329,52 +30520,19 @@ class Window(Widget, Native, Root, ShortcutManager):
         handle_menubar_accel: bool
         hide_on_close: bool
         icon_name: str | None
-        is_active: bool
+        @property
+        def is_active(self) -> bool: ...
         maximized: bool
         mnemonics_visible: bool
         modal: bool
         resizable: bool
-        suspended: bool
+        startup_id: str
+        @property
+        def suspended(self) -> bool: ...
         title: str | None
         titlebar: Widget | None
         transient_for: Window | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
-        startup_id: str
 
     @property
     def props(self) -> Props: ...
@@ -34407,6 +30565,7 @@ class Window(Widget, Native, Root, ShortcutManager):
         title: str | None = ...,
         titlebar: Widget | None = ...,
         transient_for: Window | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -34437,7 +30596,6 @@ class Window(Widget, Native, Root, ShortcutManager):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def close(self) -> None: ...
     def destroy(self) -> None: ...
@@ -34612,46 +30770,13 @@ class WindowControls(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         decoration_layout: str | None
-        empty: bool
+        @property
+        def empty(self) -> bool: ...
         side: PackType
         use_native_controls: bool
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -34662,6 +30787,7 @@ class WindowControls(Widget):
         decoration_layout: str | None = ...,
         side: PackType = ...,
         use_native_controls: bool = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -34692,7 +30818,6 @@ class WindowControls(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_decoration_layout(self) -> str | None: ...
     def get_empty(self) -> bool: ...
@@ -34821,43 +30946,9 @@ class WindowHandle(Widget):
     Signals from GObject:
       notify (GParam)
     """
+    @type_check_only
     class Props(Widget.Props):
         child: Widget | None
-        can_focus: bool
-        can_target: bool
-        css_classes: list[str]
-        css_name: str
-        cursor: _Gdk4.Cursor | None
-        focus_on_click: bool
-        focusable: bool
-        halign: Align
-        has_default: bool
-        has_focus: bool
-        has_tooltip: bool
-        height_request: int
-        hexpand: bool
-        hexpand_set: bool
-        layout_manager: LayoutManager | None
-        limit_events: bool
-        margin_bottom: int
-        margin_end: int
-        margin_start: int
-        margin_top: int
-        name: str
-        opacity: float
-        overflow: Overflow
-        parent: Widget | None
-        receives_default: bool
-        root: Root | None
-        scale_factor: int
-        sensitive: bool
-        tooltip_markup: str | None
-        tooltip_text: str | None
-        valign: Align
-        vexpand: bool
-        vexpand_set: bool
-        visible: bool
-        width_request: int
         accessible_role: AccessibleRole
 
     @property
@@ -34866,6 +30957,7 @@ class WindowHandle(Widget):
         self,
         *,
         child: Widget | None = ...,
+        accessible_role: AccessibleRole = ...,
         can_focus: bool = ...,
         can_target: bool = ...,
         css_classes: Sequence[str] = ...,
@@ -34896,7 +30988,6 @@ class WindowHandle(Widget):
         vexpand_set: bool = ...,
         visible: bool = ...,
         width_request: int = ...,
-        accessible_role: AccessibleRole = ...,
     ) -> None: ...
     def get_child(self) -> Widget | None: ...
     @classmethod

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -25,6 +25,8 @@ import pprint
 import re
 import textwrap
 from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Iterator
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import InitVar
@@ -72,6 +74,7 @@ ALLOWED_FUNCTIONS = {
     "__enter__",
     "__exit__",
     "__iter__",
+    "__next__",
     "__getitem__",
     "__setitem__",
     "__len__",
@@ -91,58 +94,6 @@ def fix_argument_name(name: str) -> str:
     if name in RESERVED_KEYWORDS:
         name = f"_{name}"
     return name.replace("-", "_")
-
-
-def _object_get_props(
-    repo: GIRepository.Repository,
-    obj: GI.ObjectInfo,
-) -> tuple[list[GIRepository.PropertyInfo], list[GIRepository.PropertyInfo]]:
-    parents: list[GI.ObjectInfo] = []
-    parent: GI.ObjectInfo | None = obj.get_parent()
-    while parent:
-        parents.append(parent)
-        parent = parent.get_parent()
-
-    interfaces = list(obj.get_interfaces())
-
-    subclasses = parents + interfaces
-
-    props = list(obj.get_properties())
-    for s in subclasses:
-        props.extend(s.get_properties())
-
-    readable_props: list[GIRepository.PropertyInfo] = []
-    writable_props: list[GIRepository.PropertyInfo] = []
-
-    for prop in props:
-        namespace = prop.get_namespace()
-        container = prop.get_container()
-
-        class_info = repo.find_by_name(namespace, container.get_name())
-        if class_info is None:
-            raise Exception(f"Unable to find {namespace}.{container}")
-
-        if isinstance(class_info, GIRepository.ObjectInfo):
-            for i in range(class_info.get_n_properties()):
-                p = class_info.get_property(i)
-                if p.get_name() == prop.get_name():
-                    flags = p.get_flags()
-                    if flags & GObject.ParamFlags.READABLE:
-                        readable_props.append(p)
-                    if flags & GObject.ParamFlags.WRITABLE:
-                        writable_props.append(p)
-
-        if isinstance(class_info, GIRepository.InterfaceInfo):
-            for i in range(class_info.get_n_properties()):
-                p = class_info.get_property(i)
-                if p.get_name() == prop.get_name():
-                    flags = p.get_flags()
-                    if flags & GObject.ParamFlags.READABLE:
-                        readable_props.append(p)
-                    if flags & GObject.ParamFlags.WRITABLE:
-                        writable_props.append(p)
-
-    return (readable_props, writable_props)
 
 
 def _callable_get_arguments(
@@ -361,10 +312,7 @@ def _type_to_python(
 
 
 def _generate_full_name(prefix: str, name: str) -> str:
-    full_name = name
-    if len(prefix) > 0:
-        full_name = f"{prefix}.{name}"
-    return full_name
+    return f"{prefix}.{name}" if prefix else name
 
 
 def _build_function_info(
@@ -588,6 +536,451 @@ def _replace_union(formatted: str) -> str:
 
 
 @dataclass(slots=True)
+class PropertyInfo:
+    stub: Stub
+    gir_info: GIRepository.PropertyInfo
+
+    gobject_name: str = field(init=False)
+    name: str = field(init=False)
+
+    _init_type: str | None = field(init=False, default=None)
+    _prop_type: str | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        self.gobject_name = f"{self.gir_info.get_name()}"
+        self.name = fix_argument_name(self.gobject_name)
+
+    @property
+    def readable(self) -> bool:
+        return bool(self.gir_info.get_flags() & GObject.ParamFlags.READABLE)
+
+    @property
+    def writable(self) -> bool:
+        return bool(self.gir_info.get_flags() & GObject.ParamFlags.WRITABLE)
+
+    @property
+    def construct(self) -> bool:
+        return bool(self.gir_info.get_flags() & GObject.ParamFlags.CONSTRUCT)
+
+    @property
+    def construct_only(self) -> bool:
+        return bool(self.gir_info.get_flags() & GObject.ParamFlags.CONSTRUCT_ONLY)
+
+    @property
+    def prop_type(self) -> str:
+        if self._prop_type is not None:
+            return self._prop_type
+
+        py_type = _type_to_python(self.stub, self.gir_info.get_type_info(), True)
+        getter = self.gir_info.get_getter()
+        setter = self.gir_info.get_setter()
+
+        if (getter and getter.may_return_null()) or (
+            # If it is wratable only prop, check if setter can accept NULL
+            setter and setter.get_arg(0).may_be_null()
+        ):
+            py_type = f"{py_type} | None"
+
+        self._prop_type = py_type
+
+        return py_type
+
+    @property
+    def init_type(self) -> str:
+        if self._init_type is not None:
+            return self._init_type
+
+        py_type = _type_to_python(self.stub, self.gir_info.get_type_info())
+        setter = self.gir_info.get_setter()
+
+        if setter and setter.get_arg(0).may_be_null():
+            py_type = f"{py_type} | None"
+
+        self._init_type = py_type
+
+        return py_type
+
+
+PropertyInfoDict: TypeAlias = dict[str, PropertyInfo]
+_MISSING = object()
+
+
+@dataclass(slots=True)
+class ClassInfo:
+    stub: Stub
+    cls: type[Any]
+    name: str
+    prefix: str
+    in_class: Any | None
+    full_name: str = field(init=False)
+
+    _bases: tuple[type[Any], ...] | None = field(init=False, default=None)
+    _gi_info: GI.RegisteredTypeInfo | None = field(
+        init=False, default=cast(Any, _MISSING)
+    )
+    _class_properties: PropertyInfoDict | None = field(init=False, default=None)
+    _init_properties: PropertyInfoDict | None = field(init=False, default=None)
+    _class_content: str | None = field(init=False, default=None)
+    _fields: list[GI.FieldInfo] | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        self.full_name = _generate_full_name(self.prefix, self.name)
+
+    @property
+    def is_interface(self) -> bool:
+        return isinstance(self.gi_info, GI.InterfaceInfo)
+
+    @property
+    def is_object(self) -> bool:
+        return isinstance(self.gi_info, GI.ObjectInfo)
+
+    @property
+    def bases(self) -> tuple[type[Any], ...]:
+        if self._bases is not None:
+            return self._bases
+
+        self._bases, self._gi_info = self.__get_bases_and_gi_info()
+
+        return self._bases
+
+    @property
+    def gi_info(self) -> GI.RegisteredTypeInfo | None:
+        if self._gi_info is not _MISSING:
+            return self._gi_info
+
+        self._bases, self._gi_info = self.__get_bases_and_gi_info()
+
+        return self._gi_info
+
+    @property
+    def properties(self) -> PropertyInfoDict:
+        if self._class_properties is not None:
+            return self._class_properties
+
+        self._class_properties, self._init_properties = self.__get_properties()
+
+        return self._class_properties
+
+    @property
+    def init_properties(self) -> PropertyInfoDict:
+        if self._init_properties is not None:
+            return self._init_properties
+
+        self._class_properties, self._init_properties = self.__get_properties()
+
+        return self._init_properties
+
+    @property
+    def contents(self) -> str:
+        if self._class_content is not None:
+            return self._class_content
+
+        self._class_content, self._fields = self.__get_contents_and_fields()
+
+        return self._class_content
+
+    @property
+    def fields(self) -> list[GI.FieldInfo]:
+        if self._fields is not None:
+            return self._fields
+
+        self._class_content, self._fields = self.__get_contents_and_fields()
+
+        return self._fields
+
+    def __get_bases_and_gi_info(
+        self,
+    ) -> tuple[tuple[type[Any], ...], GI.RegisteredTypeInfo | None]:
+        full_module_name = f"{self.cls.__module__}.{self.cls.__qualname__}"
+        object_info = self.cls.__dict__.get("__info__")
+        bases = list(get_original_bases(self.cls))
+
+        # Because we're generating types for gi.repository, we have to generate stubs for
+        # override classes that come from gi.repository and inherit from gi.repository classes.
+        # Effectively, we want to write the stubs as if the override class and repository class
+        # are one class in the MRO. What this means is that the following transformations need to
+        # happen:
+        # 1. For the following:
+        #    gi.repository.X.One(<One repository bases>)
+        #    gi.overrides.X.One(<One prefix override bases>, gi.repository.X.One, <One suffix override bases>) ->
+        #        gi.repository.X.One(<One prefix override bases>, <One repository bases>, <One override bases>)
+        # 2. gi.overrides.X.Two(float) -> gi.repository.X.Two(float)
+        # 3. gi.overrides.X.Three(gi.overrides.X.Four, ...) -> gi.repository.X.Three(gi.repository.X.Four, ...)
+        if full_module_name.startswith("gi.overrides.") and any(
+            base.__module__.startswith("gi.repository.") for base in bases
+        ):
+            bases: list[Any] = []
+            gi_repo_full_name = full_module_name.replace(
+                "gi.overrides.", "gi.repository.", 1
+            )
+
+            for base in get_original_bases(self.cls):
+                if f"{base.__module__}.{base.__qualname__}" == gi_repo_full_name:
+                    bases.extend(get_original_bases(base))
+
+                    if object_info is None:
+                        object_info = base.__dict__.get("__info__")
+                elif base is not object and base not in bases:
+                    bases.append(base)
+
+        if GI.GInterface in bases and not any(
+            get_origin(base) is Protocol for base in bases
+        ):
+            # Most overrides use Generic instead of Protocol for interfaces
+            index = next(
+                (
+                    i
+                    for i, base in enumerate(bases)
+                    if get_origin(base) is Generic and get_args(base)
+                ),
+                None,
+            )
+            if index is None:
+                bases.append(Protocol)
+            else:
+                args = get_args(bases[index])
+                bases[index] = GenericAlias(cast(Any, Protocol), args)
+
+        return tuple(bases), object_info
+
+    def __find_repo_property(
+        self, prop_info: GI.PropertyInfo, /
+    ) -> GIRepository.PropertyInfo | None:
+        class_info = self.stub.repo.find_by_name(
+            prop_info.get_namespace(), f"{prop_info.get_container().get_name()}"
+        )
+        prop_name = prop_info.get_name()
+
+        if isinstance(
+            class_info, (GIRepository.ObjectInfo, GIRepository.InterfaceInfo)
+        ):
+            for i in range(class_info.get_n_properties()):
+                property = class_info.get_property(i)
+                if property.get_name() == prop_name:
+                    return property
+
+        return None
+
+    def __iterate_class_properties(
+        self,
+        gi_info: GI.ObjectInfo | GI.InterfaceInfo,
+        *,
+        include_interfaces: bool = False,
+    ) -> Iterator[PropertyInfo]:
+        interface_properties: Iterable[tuple[GI.PropertyInfo, ...]] = (
+            (iface.get_properties() for iface in gi_info.get_interfaces())
+            if isinstance(gi_info, GI.ObjectInfo) and include_interfaces
+            else []
+        )
+
+        yield from (
+            PropertyInfo(self.stub, prop_info)
+            for prop in itertools.chain(gi_info.get_properties(), *interface_properties)
+            if (prop_info := self.__find_repo_property(prop)) is not None
+        )
+
+    def __iterate_parents(self) -> Iterator[GI.ObjectInfo]:
+        if not isinstance(self.gi_info, GI.ObjectInfo):
+            return
+
+        current = self.gi_info.get_parent()
+        while current is not None:
+            yield current
+            current = current.get_parent()
+
+    def __iterate_parent_class_properties(self) -> Iterator[PropertyInfo]:
+        for parent in self.__iterate_parents():
+            yield from self.__iterate_class_properties(parent)
+
+    def __get_properties(self) -> tuple[PropertyInfoDict, PropertyInfoDict]:
+        if not isinstance(self.gi_info, (GI.ObjectInfo, GI.InterfaceInfo)):
+            return {}, {}
+
+        names: set[str] = set()
+        class_props: PropertyInfoDict = {}
+        init_props: PropertyInfoDict = {}
+
+        for prop_info in self.__iterate_class_properties(
+            self.gi_info, include_interfaces=True
+        ):
+            if (name := prop_info.name) in names:
+                continue
+
+            names.add(name)
+
+            if prop_info.readable or (
+                prop_info.writable and not prop_info.construct_only
+            ):
+                class_props[name] = prop_info
+
+            if prop_info.writable or prop_info.construct or prop_info.construct_only:
+                init_props[name] = prop_info
+
+        for prop_info in self.__iterate_parent_class_properties():
+            if (name := prop_info.name) in names:
+                continue
+
+            names.add(name)
+
+            if prop_info.writable or prop_info.construct or prop_info.construct_only:
+                init_props[name] = prop_info
+
+        return class_props, init_props
+
+    def __get_contents_and_fields(self) -> tuple[str, list[GI.FieldInfo]]:
+        return _gi_build_stub_parts(
+            self.stub, self.cls, _find_attributes(self.cls), self.cls, self.full_name
+        )
+
+    def __build_docstring(self) -> str | None:
+        # extracting docs
+        docs = (
+            f"{(getattr(self.cls, '__doc__', '') or '').strip()}\n\n{
+                getattr(self.cls, '__gdoc__', '') or ''
+            }"
+        ).strip()
+
+        if docs:
+            docs = '"""\n' + docs.strip() + '\n"""'
+            return docs
+
+        return None
+
+    def __build_props_class(self) -> str | None:
+        if override := self.stub.check_override(self.full_name, "Props"):
+            return override
+
+        if (
+            not isinstance(self.gi_info, (GI.ObjectInfo, GI.InterfaceInfo))
+            or not self.properties
+        ):
+            return None
+
+        lines: list[str] = []
+
+        for name, prop_info in self.properties.items():
+            py_type = prop_info.prop_type
+
+            if prop_info.readable and (
+                not prop_info.writable or prop_info.construct_only
+            ):
+                lines.append(self.stub.get_property(name, py_type))
+            else:
+                lines.append(f"{name}: {py_type}")
+
+        props_string = "\n".join(lines) or "..."
+
+        parents_string = ""
+        if isinstance(self.gi_info, GI.ObjectInfo) and (
+            parent := self.gi_info.get_parent()
+        ):
+            parent_name = f"{parent.get_name()}"
+            parents_string = f"({self.stub.get_namespace_member(parent.get_namespace(), parent_name)}.Props)"
+
+        return f"""@{self.stub.get_import("typing", "type_check_only")}
+class Props{parents_string}:
+{textwrap.indent(props_string, "    ")}"""
+
+    def __build_props_property(self, props_class: str | None) -> str | None:
+        if override := self.stub.check_override(self.full_name, "props"):
+            return override
+
+        if isinstance(self.gi_info, GI.ObjectInfo) and props_class is not None:
+            return self.stub.get_property("props", "Props")
+
+        return None
+
+    def __build_props(self) -> str | None:
+        lines: list[str] = []
+
+        if (props_class := self.__build_props_class()) is not None:
+            lines.append(props_class)
+
+        if (props_property := self.__build_props_property(props_class)) is not None:
+            lines.append(props_property)
+
+        return "\n".join(lines) if lines else None
+
+    def __build_fields(self) -> str:
+        lines: list[str] = []
+
+        for field in self.fields:
+            name = f"{field.get_name()}"
+
+            if override := self.stub.check_override(self.full_name, name):
+                lines.append(override)
+            else:
+                py_type = _type_to_python(self.stub, field.get_type_info(), True)
+                flags = field.get_flags()
+                if not (flags & _IS_FIELD_WRITABLE):
+                    lines.append(self.stub.get_property(name, py_type))
+                else:
+                    lines.append(f"{name}: {py_type}")
+
+        return "\n".join(lines)
+
+    def __build_init(self) -> str | None:
+        if override := self.stub.check_override(self.full_name, "__init__"):
+            return override
+
+        if not isinstance(self.gi_info, GI.ObjectInfo) or not self.init_properties:
+            return None
+
+        args: list[str] = []
+
+        for name, init_prop in self.init_properties.items():
+            args.append(f"{name}: {init_prop.init_type} = ...")
+
+        return f"def __init__(self, *, {', '.join(args)}) -> None: ..."
+
+    def build(self) -> str:
+        if override := self.stub.check_override(self.prefix, self.name):
+            return override
+
+        if (
+            not self.in_class
+            and (alias := self.stub.get_alias(self.name, self.cls)) is not None
+        ):
+            # Set up a constant for classes that are aliases
+            # NOTE: this should not use `Final` because doing so turns the alias into
+            # a variable rather than a class
+            return f"{self.name} = {alias}"
+
+        string_parents = ""
+        if self.bases:
+            bases_strings = [
+                self.stub.get_class_import(base)
+                for base in self.bases
+                if base is not object
+            ]
+
+            string_parents = f"({', '.join(bases_strings)})"
+
+        lines = [f"class {self.name}{string_parents}:"]
+
+        if docs := self.__build_docstring():
+            lines.append(textwrap.indent(docs, "    "))
+
+        if self.is_object and (props := self.__build_props()) is not None:
+            lines.append(textwrap.indent(props, "    "))
+
+        if class_fields := self.__build_fields():
+            lines.append(textwrap.indent(class_fields, "    "))
+
+        if class_constructor := self.__build_init():
+            lines.append(textwrap.indent(class_constructor, "    "))
+
+        lines.append(textwrap.indent(self.contents, "    "))
+
+        class_string = "\n".join(lines).strip()
+
+        if class_string.endswith(":"):
+            class_string += " ..."
+
+        return class_string
+
+
+@dataclass(slots=True)
 class Stub:
     repo: GIRepository.Repository
     parent: ObjectT
@@ -714,7 +1107,7 @@ class Stub:
         self, name: str, return_annotation: str, /, *, indent: str = ""
     ) -> str:
         property_symbol = self.get_import("builtins", "property")
-        return f"{indent}@{property_symbol}\n{indent}def {name}(self) -> {return_annotation}: ...\n"
+        return f"{indent}@{property_symbol}\n{indent}def {name}(self) -> {return_annotation}: ..."
 
     def get_class_import(self, cls: Any, /) -> str:
         # Things like Generic and Protocol show up in the MRO as `Generic` rather than
@@ -746,59 +1139,6 @@ class Stub:
 
         module, name = full_name.rsplit(".", 1)
         return f"{self.get_import(module, name)}{args}"
-
-    def get_class_info(
-        self, cls: type[Any], /
-    ) -> tuple[tuple[type[Any], ...], GI.RegisteredTypeInfo | None]:
-        full_name = f"{cls.__module__}.{cls.__qualname__}"
-        object_info: GI.RegisteredTypeInfo | None = cls.__dict__.get("__info__")
-        bases = list(get_original_bases(cls))
-
-        # Because we're generating types for gi.repository, we have to generate stubs for
-        # override classes that come from gi.repository and inherit from gi.repository classes.
-        # Effectively, we want to write the stubs as if the override class and repository class
-        # are one class in the MRO. What this means is that the following transformations need to
-        # happen:
-        # 1. For the following:
-        #    gi.repository.X.One(<One repository bases>)
-        #    gi.overrides.X.One(<One prefix override bases>, gi.repository.X.One, <One suffix override bases>) ->
-        #        gi.repository.X.One(<One prefix override bases>, <One repository bases>, <One override bases>)
-        # 2. gi.overrides.X.Two(float) -> gi.repository.X.Two(float)
-        # 3. gi.overrides.X.Three(gi.overrides.X.Four, ...) -> gi.repository.X.Three(gi.repository.X.Four, ...)
-        if full_name.startswith("gi.overrides.") and any(
-            base.__module__.startswith("gi.repository.") for base in bases
-        ):
-            bases: list[Any] = []
-            gi_repo_full_name = full_name.replace("gi.overrides.", "gi.repository.", 1)
-
-            for base in get_original_bases(cls):
-                if f"{base.__module__}.{base.__qualname__}" == gi_repo_full_name:
-                    bases.extend(get_original_bases(base))
-
-                    if object_info is None:
-                        object_info = base.__dict__.get("__info__")
-                elif base is not object:
-                    bases.append(base)
-
-        if GI.GInterface in bases and not any(
-            get_origin(base) is Protocol for base in bases
-        ):
-            # Most overrides use Generic instead of Protocol for interfaces
-            index = next(
-                (
-                    i
-                    for i, base in enumerate(bases)
-                    if get_origin(base) is Generic and get_args(base)
-                ),
-                None,
-            )
-            if index is None:
-                bases.append(Protocol)
-            else:
-                args = get_args(bases[index])
-                bases[index] = GenericAlias(cast(Any, Protocol), args)
-
-        return tuple(bases), object_info
 
     def __replace_typing(self, match: re.Match[str]) -> str:
         match match.group("name"):
@@ -917,7 +1257,7 @@ def _gi_build_stub_parts(
     Inspect the passed module recursively and build stubs for functions,
     classes, etc.
     """
-    classes: dict[str, type[Any]] = {}
+    classes: dict[str, ClassInfo] = {}
     functions: dict[str, Callable[..., Any]] = {}
     constants: dict[str, Any] = {}
     flags: dict[str, type[Any]] = {}
@@ -944,7 +1284,7 @@ def _gi_build_stub_parts(
             elif issubclass(obj, IntEnum):
                 enums[name] = obj
             else:
-                classes[name] = obj
+                classes[name] = ClassInfo(stub, obj, name, prefix_name, in_class)
         elif inspect.isfunction(obj) or inspect.isbuiltin(obj):
             functions[name] = obj
         elif inspect.ismethoddescriptor(obj):
@@ -1040,167 +1380,9 @@ def _gi_build_stub_parts(
         ret += "\n"
 
     # Classes
-    for name, obj in sorted(classes.items()):
-        override = stub.check_override(prefix_name, name)
-        if override:
-            ret += override + "\n\n"
-            continue
-
-        if in_class is None and (alias := stub.get_alias(name, obj)) is not None:
-            # Set up a constant for classes that are aliases
-            # NOTE: this should not use `Final` because doing so turns the alias into
-            # a variable rather than a class
-            ret += f"{name} = {alias}\n"
-            continue
-
-        full_name = _generate_full_name(prefix_name, name)
-
-        classret, fields = _gi_build_stub_parts(
-            stub,
-            obj,
-            _find_attributes(obj),
-            obj,
-            full_name,
-        )
-
-        readable_props: list[GIRepository.PropertyInfo] = []
-        writable_props: list[GIRepository.PropertyInfo] = []
-        props_parents: list[str] = []
-        class_bases, class_object_info = stub.get_class_info(obj)
-
-        if class_object_info is not None:
-            if isinstance(class_object_info, GI.ObjectInfo):
-                p = class_object_info.get_parent()
-                if p:
-                    props_parents.append(
-                        f"{stub.get_namespace_member(p.get_namespace(), p.get_name())}.Props"
-                    )
-
-                # Properties
-                (rp, wp) = _object_get_props(stub.repo, class_object_info)
-                readable_props.extend(rp)
-                writable_props.extend(wp)
-
-        string_parents = ""
-        if class_bases:
-            bases_strings = [
-                stub.get_class_import(base)
-                for base in class_bases
-                if base is not object
-            ]
-
-            string_parents = f"({', '.join(bases_strings)})"
-
-        if (
-            not classret
-            and len(fields) == 0
-            and len(readable_props) == 0
-            and len(writable_props) == 0
-        ):
-            ret += f"class {name}{string_parents}: ...\n"
-        else:
-            ret += f"class {name}{string_parents}:\n"
-
-            # extracting docs
-            doc = getattr(obj, "__doc__", "") or ""
-            gdoc = getattr(obj, "__gdoc__", "") or ""
-
-            txt = doc.strip() + "\n\n" + gdoc.strip()
-            if not txt.isspace():
-                txt = '"""\n' + txt.strip() + '\n"""' + "\n"
-                txt = textwrap.indent(txt, "    ")
-                ret += txt
-
-        props_class_override = stub.check_override(full_name, "Props")
-        if props_class_override:
-            for line in props_class_override.splitlines():
-                ret += "    " + line + "\n"
-        elif readable_props or writable_props:
-            names: list[str] = []
-            s: list[str] = []
-            for p in itertools.chain(readable_props, writable_props):
-                n = fix_argument_name(p.get_name())
-                if n in names:
-                    # Avoid duplicates
-                    continue
-                names.append(n)
-                t = _type_to_python(stub, p.get_type_info(), True)
-
-                # Check getter/setter
-                getter = p.get_getter()
-                setter = p.get_setter()
-                if getter and getter.may_return_null():
-                    s.append(f"{n}: {t} | None")
-                elif setter and not getter:
-                    # If is writable only prop check if setter can accept NULL
-                    arg_info = setter.get_arg(0)
-                    if arg_info.may_be_null():
-                        s.append(f"{n}: {t} | None")
-                    else:
-                        s.append(f"{n}: {t}")
-                else:
-                    s.append(f"{n}: {t}")
-
-            props_string_parents = (
-                f"({', '.join(props_parents)})" if props_parents else ""
-            )
-
-            separator = "\n        "
-            ret += f"    class Props{props_string_parents}:{separator}"
-            ret += separator.join(s)
-            ret += "\n"
-
-        props_override = stub.check_override(full_name, "props")
-        if props_override:
-            for line in props_override.splitlines():
-                ret += "    " + line + "\n"
-        elif props_class_override or readable_props or writable_props:
-            ret += stub.get_property("props", "Props", indent="    ")
-
-        for f in fields:
-            t = _type_to_python(stub, f.get_type_info(), True)
-            n = f.get_name()
-            override = stub.check_override(full_name, n)
-            if override:
-                ret += f"    {override}\n"
-            else:
-                field_flags = f.get_flags()
-                if not (field_flags & _IS_FIELD_WRITABLE):
-                    ret += stub.get_property(n, t, indent="    ")
-                else:
-                    ret += f"    {n}: {t}\n"
-
-        class_constructor_override = stub.check_override(full_name, "__init__")
-        if class_constructor_override:
-            for line in class_constructor_override.splitlines():
-                ret += "    " + line + "\n"
-        elif len(writable_props) > 0:
-            names: list[str] = []
-            s: list[str] = []
-            for p in writable_props:
-                n = fix_argument_name(p.get_name())
-                if n in names:
-                    # Avoid duplicates
-                    continue
-                names.append(n)
-                t = _type_to_python(stub, p.get_type_info())
-                setter = p.get_setter()
-                if setter:
-                    arg_info = setter.get_arg(0)
-                    if arg_info.may_be_null():
-                        s.append(f"{n}: {t} | None = ...")
-                    else:
-                        s.append(f"{n}: {t} = ...")
-                else:
-                    s.append(f"{n}: {t} = ...")
-
-            separator = ",\n                 "
-            ret += f"    def __init__(self, *, {separator.join(s)}) -> None: ...\n"
-
-        for line in classret.splitlines():
-            ret += "    " + line + "\n"
-
-        ret += "\n"
+    for name, class_info in sorted(classes.items()):
+        if class_string := class_info.build():
+            ret += f"{class_string}\n"
 
     if ret and flags:
         ret += "\n"


### PR DESCRIPTION
- Encapsulate class information and generation logic in `ClassInfo`
- Encapsulate property information logic in `PropertyInfo`
- Mark `Props` classes as only available during type checking
- Only include the current class's properties in `Props`
- Only include writable and construct-only properties in `__init__` arguments
- Make readonly props `@property` in `Props`
- Include the doc string for all classes that have one