### PR TITLE
Types for GLib io_add_watch and timeout_add

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "PyGObject-stubs"
 version = "2.17.0"
 description = "Typing stubs for PyGObject"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "LGPL-2.1"}
 authors = [
   {email = "reiter.christoph@gmail.com"},
@@ -58,7 +58,7 @@ exclude = [
   ".venv",
 ]
 
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [
@@ -88,4 +88,4 @@ section-order = ["future", "typing", "standard-library", "third-party", "first-p
 typing = ["_typeshed", "typing", "typing_extensions"]
 
 [tool.pyright]
-pythonVersion = "3.10"
+pythonVersion = "3.11"

--- a/src/gi-stubs/_error.pyi
+++ b/src/gi-stubs/_error.pyi
@@ -1,4 +1,4 @@
-from typing_extensions import Self
+from typing import Self
 
 class GError(RuntimeError):
     message: str

--- a/src/gi-stubs/_gi.pyi
+++ b/src/gi-stubs/_gi.pyi
@@ -2,8 +2,8 @@ from typing import Any
 from typing import ClassVar
 from typing import Final
 from typing import Protocol
+from typing import Self
 from typing import type_check_only
-from typing_extensions import Self
 
 from builtins import Warning as _Warning
 from collections.abc import Callable

--- a/src/gi-stubs/_gtktemplate.pyi
+++ b/src/gi-stubs/_gtktemplate.pyi
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import overload
+from typing import Self
 from typing import TypeVar
-from typing_extensions import Self
 
 import os
 from collections.abc import Callable

--- a/src/gi-stubs/_signalhelper.pyi
+++ b/src/gi-stubs/_signalhelper.pyi
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Literal
 from typing import overload
-from typing_extensions import Self
+from typing import Self
 
 from collections.abc import Callable
 from collections.abc import Sequence

--- a/src/gi-stubs/events.pyi
+++ b/src/gi-stubs/events.pyi
@@ -1,5 +1,5 @@
 from typing import Any
-from typing_extensions import Self
+from typing import Self
 
 from collections.abc import Callable
 from signal import Signals

--- a/src/gi-stubs/repository/GLib.pyi
+++ b/src/gi-stubs/repository/GLib.pyi
@@ -1,7 +1,8 @@
 from typing import Any
 from typing import Final
+from typing import Self
 from typing import TypeVar
-from typing_extensions import Self
+from typing import TypeVarTuple
 
 from collections.abc import Callable
 from collections.abc import Iterable
@@ -15,6 +16,7 @@ from gi._error import GError as _GError
 from gi.repository import GObject
 
 T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
 
 ALLOCATOR_LIST: Final[int]
 ALLOCATOR_NODE: Final[int]
@@ -620,11 +622,13 @@ def int_equal(v1: None, v2: None) -> bool: ...
 def int_hash(v: None) -> int: ...
 def intern_static_string(string: str | None = None) -> str: ...
 def intern_string(string: str | None = None) -> str: ...
-def io_add_watch(*args, **kwargs) -> int:
-    """
-    io_add_watch(channel, priority, condition, func, *user_data) -> event_source_id.
-    """  # FIXME: Override is missing typing annotation
-
+def io_add_watch(
+    channel: IOChannel,
+    priority: int,
+    condition: IOChannel,
+    func: Callable[[IOChannel, IOCondition, *Ts], bool],
+    *user_data: *Ts,
+) -> int: ...
 def io_channel_error_from_errno(en: int) -> IOChannelError: ...
 def io_channel_error_quark() -> int: ...
 def io_create_watch(channel: IOChannel, condition: IOCondition) -> Source: ...
@@ -1022,15 +1026,15 @@ def threads_init(): ...  # FIXME: Override is missing typing annotation
 def time_val_from_iso8601(iso_date: str) -> tuple[bool, TimeVal]: ...
 def timeout_add(
     interval: int,
-    function: Callable[..., bool | None],
-    *user_data: Any,
-    priority: int = 0,
+    function: Callable[[*Ts], bool | None],
+    *user_data: *Ts,
+    priority: int = PRIORITY_DEFAULT,
 ) -> int: ...
 def timeout_add_seconds(
     interval: int,
-    function: Callable[..., bool | None],
-    *user_data: Any,
-    priority: int = 0,
+    function: Callable[[*Ts], bool | None],
+    *user_data: *Ts,
+    priority: int = PRIORITY_DEFAULT,
 ) -> int: ...
 def timeout_source_new(interval: int) -> Source: ...
 def timeout_source_new_seconds(interval: int) -> Source: ...

--- a/src/gi-stubs/repository/Gio.pyi
+++ b/src/gi-stubs/repository/Gio.pyi
@@ -3,9 +3,9 @@ from typing import Final
 from typing import Generic
 from typing import overload
 from typing import Protocol
+from typing import Self
 from typing import type_check_only
 from typing import TypeVar
-from typing_extensions import Self
 
 from collections.abc import Callable
 from collections.abc import Iterator

--- a/src/gi-stubs/repository/Gst.pyi
+++ b/src/gi-stubs/repository/Gst.pyi
@@ -2,9 +2,9 @@ from typing import Any
 from typing import Final
 from typing import Generic
 from typing import Protocol
+from typing import Self
 from typing import type_check_only
 from typing import TypeVar
-from typing_extensions import Self
 
 from collections.abc import Callable
 from collections.abc import Iterable

--- a/src/gi-stubs/repository/_Gtk4.pyi
+++ b/src/gi-stubs/repository/_Gtk4.pyi
@@ -1,9 +1,9 @@
 from typing import Any
 from typing import Final
 from typing import Protocol
+from typing import Self
 from typing import type_check_only
 from typing import TypeVar
-from typing_extensions import Self
 
 from collections.abc import Callable
 from collections.abc import Collection

--- a/tools/parse.py
+++ b/tools/parse.py
@@ -1,7 +1,7 @@
 from typing import cast
 from typing import Final
+from typing import Self
 from typing import TypeAlias
-from typing_extensions import Self
 
 import ast
 import re


### PR DESCRIPTION
This PR correctly types the user_data args for two functions I use often, and increases minimum python version to 3.11 in `pyproject.toml` to account for the star annotation of `*user_data: *Ts` which was added in python 3.11.

As a result of the python version switch, the ruff and pyright config has been updated, resulting in several changes to `from typing_extensions import Self`.

The use of TypeVarTuple allows pyright/mypy to inspect the types of the callback function.

Question: [pygobject massages input args for `io_add-watch`](https://gitlab.gnome.org/GNOME/pygobject/-/blob/main/gi/overrides/GLib.py?ref_type=heads#L801), so in reality the typing for this function is far more complex. Should this be reflected in this type stub?