### PR TITLE
imprv: generate async overloads for finish-func methods

### DIFF
--- a/src/gi-stubs/_gi.pyi
+++ b/src/gi-stubs/_gi.pyi
@@ -1,15 +1,20 @@
 from typing import Any
 from typing import ClassVar
 from typing import Final
+from typing import final
+from typing import Generic
 from typing import Protocol
 from typing import type_check_only
 from typing_extensions import Self
+from typing_extensions import TypeVar
 
 from builtins import Warning as _Warning
 from collections.abc import Callable
+from collections.abc import Generator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
+from contextvars import Context
 from enum import IntEnum
 from enum import IntFlag
 from inspect import Signature
@@ -17,6 +22,8 @@ from inspect import Signature
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import GObject as _GObject
+
+_T_co = TypeVar("_T_co", covariant=True, default=Any)
 
 G_MAXDOUBLE: Final[float]
 G_MAXFLOAT: Final[float]
@@ -60,23 +67,24 @@ class ArrayType(int):
     C: ClassVar[int]
     PTR_ARRAY: ClassVar[int]
 
-class Async:
+@final
+class Async(Generic[_T_co]):
     cancellable: Gio.Cancellable | None
     def __init__(
         self, finish_func: CallableInfo, cancellable: Gio.Cancellable | None = None
     ) -> None: ...
     def add_done_callback(
-        self, callback: Callable[..., Any], *, context: object = None
+        self, callback: Callable[[Self], object], *, context: Context | None = None
     ) -> None: ...
-    def cancel(self) -> None: ...
+    def cancel(self, msg: str | None = None) -> None: ...
     def done(self) -> bool: ...
     def exception(self) -> BaseException | None: ...
-    def remove_done_callback(self, callback: Callable[..., Any], /) -> int: ...
-    def result(self) -> Any: ...
-    def __await__(self) -> Async: ...
+    def remove_done_callback(self, callback: Callable[[Self], object], /) -> int: ...
+    def result(self) -> _T_co: ...
+    def __await__(self) -> Generator[Self, Any, _T_co]: ...
     def __del__(self) -> None: ...
-    def __iter__(self) -> Async: ...
-    def __next__(self) -> Async: ...
+    def __iter__(self) -> Self: ...
+    def __next__(self) -> Self: ...
 
 class BaseInfo:
     def equal(self, object: BaseInfo, /) -> bool: ...
@@ -333,6 +341,7 @@ class ObjectProtocol(GObjectProtocol, Protocol):
 
 class GObject(GObjectProtocol):
     __gtype__: ClassVar[GType]
+    @type_check_only
     class Props: ...
 
     @property

--- a/src/gi-stubs/repository/Adw.pyi
+++ b/src/gi-stubs/repository/Adw.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Literal
+from typing import overload
 from typing import Protocol
 from typing import type_check_only
 from typing import TypeAlias
@@ -1031,15 +1032,27 @@ class AlertDialog(Dialog):
         width_request: int = ...,
     ) -> None: ...
     def add_response(self, id: str, label: str) -> None: ...
+    @overload
     def choose(
         self,
         parent: _Gtk4.Widget | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[str]: ...
+    @overload
+    def choose(
+        self,
+        parent: _Gtk4.Widget | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[AlertDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def choose(
+        self,
+        parent: _Gtk4.Widget | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[AlertDialog] | None,
     ) -> None: ...
     def choose_finish(self, result: Gio.AsyncResult) -> str: ...
     def do_response(self, response: str) -> None: ...
@@ -5706,14 +5719,21 @@ class MessageDialog(_Gtk4.Window):
         width_request: int = ...,
     ) -> None: ...
     def add_response(self, id: str, label: str) -> None: ...
+    @overload
+    def choose(self, cancellable: Gio.Cancellable | None = None) -> _gi.Async[str]: ...
+    @overload
+    def choose(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[MessageDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def choose(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[MessageDialog] | None,
     ) -> None: ...
     def choose_finish(self, result: Gio.AsyncResult) -> str: ...
     def do_response(self, response: str) -> None: ...

--- a/src/gi-stubs/repository/GdkPixbuf.pyi
+++ b/src/gi-stubs/repository/GdkPixbuf.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Literal
+from typing import overload
 from typing import type_check_only
 from typing import TypeAlias
 from typing_extensions import TypeVarTuple
@@ -181,15 +182,26 @@ class Pixbuf(GObject.Object, Gio.Icon, Gio.LoadableIcon):
     def get_colorspace(self) -> Colorspace: ...
     @staticmethod
     def get_file_info(filename: str) -> tuple[PixbufFormat | None, int, int]: ...
+    @overload
+    @staticmethod
+    def get_file_info_async(
+        filename: str, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[tuple[PixbufFormat | None, int, int]]: ...
+    @overload
+    @staticmethod
+    def get_file_info_async(
+        filename: str,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     @staticmethod
     def get_file_info_async(
         filename: str,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[None] | None,
     ) -> None: ...
     @staticmethod
     def get_file_info_finish(
@@ -263,15 +275,26 @@ class Pixbuf(GObject.Object, Gio.Icon, Gio.LoadableIcon):
     def new_from_stream(
         cls, stream: Gio.InputStream, cancellable: Gio.Cancellable | None = None
     ) -> Pixbuf | None: ...
+    @overload
+    @staticmethod
+    def new_from_stream_async(
+        stream: Gio.InputStream, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Pixbuf | None]: ...
+    @overload
+    @staticmethod
+    def new_from_stream_async(
+        stream: Gio.InputStream,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     @staticmethod
     def new_from_stream_async(
         stream: Gio.InputStream,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_from_stream_at_scale(
@@ -409,15 +432,26 @@ class PixbufAnimation(GObject.Object):
     def new_from_stream(
         cls, stream: Gio.InputStream, cancellable: Gio.Cancellable | None = None
     ) -> PixbufAnimation | None: ...
+    @overload
+    @staticmethod
+    def new_from_stream_async(
+        stream: Gio.InputStream, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[PixbufAnimation | None]: ...
+    @overload
+    @staticmethod
+    def new_from_stream_async(
+        stream: Gio.InputStream,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     @staticmethod
     def new_from_stream_async(
         stream: Gio.InputStream,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_from_stream_finish(

--- a/src/gi-stubs/repository/Gio.pyi
+++ b/src/gi-stubs/repository/Gio.pyi
@@ -24,6 +24,11 @@ from gi.repository import GObject
 ObjectItemType = TypeVar("ObjectItemType", bound=GObject.Object, default=Any)
 ObjectPropsItemType = TypeVar("ObjectPropsItemType", bound=GObject.Object, default=Any)
 _DataTs = TypeVarTuple("_DataTs", default=Unpack[tuple[()]])
+_SourceObjectT = TypeVar("_SourceObjectT", bound=GObject.ObjectProtocol | None)
+
+AsyncReadyCallback: TypeAlias = Callable[
+    [_SourceObjectT, AsyncResult, Unpack[_DataTs]], None
+]
 
 DBUS_METHOD_INVOCATION_HANDLED: Final = True
 DBUS_METHOD_INVOCATION_UNHANDLED: Final = False
@@ -173,22 +178,45 @@ def app_info_get_all_for_type(content_type: str) -> list[AppInfo]: ...
 def app_info_get_default_for_type(
     content_type: str, must_support_uris: bool
 ) -> AppInfo | None: ...
+@overload
+def app_info_get_default_for_type_async(
+    content_type: str, must_support_uris: bool, cancellable: Cancellable | None = None
+) -> _gi.Async[AppInfo]: ...
+@overload
+def app_info_get_default_for_type_async(
+    content_type: str,
+    must_support_uris: bool,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+    *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
 def app_info_get_default_for_type_async(
     content_type: str,
     must_support_uris: bool,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
-    *user_data: Unpack[_DataTs],
+    *,
+    callback: AsyncReadyCallback[None] | None,
 ) -> None: ...
 def app_info_get_default_for_type_finish(result: AsyncResult) -> AppInfo: ...
 def app_info_get_default_for_uri_scheme(uri_scheme: str) -> AppInfo | None: ...
+@overload
+def app_info_get_default_for_uri_scheme_async(
+    uri_scheme: str, cancellable: Cancellable | None = None
+) -> _gi.Async[AppInfo]: ...
+@overload
+def app_info_get_default_for_uri_scheme_async(
+    uri_scheme: str,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+    *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
 def app_info_get_default_for_uri_scheme_async(
     uri_scheme: str,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
-    *user_data: Unpack[_DataTs],
+    *,
+    callback: AsyncReadyCallback[None] | None,
 ) -> None: ...
 def app_info_get_default_for_uri_scheme_finish(result: AsyncResult) -> AppInfo: ...
 def app_info_get_fallback_for_type(content_type: str) -> list[AppInfo]: ...
@@ -196,13 +224,27 @@ def app_info_get_recommended_for_type(content_type: str) -> list[AppInfo]: ...
 def app_info_launch_default_for_uri(
     uri: str, context: AppLaunchContext | None = None
 ) -> bool: ...
+@overload
 def app_info_launch_default_for_uri_async(
     uri: str,
     context: AppLaunchContext | None = None,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
+) -> _gi.Async[bool]: ...
+@overload
+def app_info_launch_default_for_uri_async(
+    uri: str,
+    context: AppLaunchContext | None,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
     *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
+def app_info_launch_default_for_uri_async(
+    uri: str,
+    context: AppLaunchContext | None = None,
+    cancellable: Cancellable | None = None,
+    *,
+    callback: AsyncReadyCallback[None] | None,
 ) -> None: ...
 def app_info_launch_default_for_uri_finish(result: AsyncResult) -> bool: ...
 def app_info_reset_type_associations(content_type: str) -> None: ...
@@ -216,12 +258,23 @@ def async_initable_newv_async(
     | None = None,
     *user_data: Unpack[_DataTs],
 ) -> None: ...
+@overload
+def bus_get(
+    bus_type: _BusTypeValueType, cancellable: Cancellable | None = None
+) -> _gi.Async[DBusConnection]: ...
+@overload
+def bus_get(
+    bus_type: _BusTypeValueType,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+    *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
 def bus_get(
     bus_type: _BusTypeValueType,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
-    *user_data: Unpack[_DataTs],
+    *,
+    callback: AsyncReadyCallback[None] | None,
 ) -> None: ...
 def bus_get_finish(res: AsyncResult) -> DBusConnection: ...
 def bus_get_sync(
@@ -280,12 +333,23 @@ def dbus_address_escape_value(string: str) -> str: ...
 def dbus_address_get_for_bus_sync(
     bus_type: _BusTypeValueType, cancellable: Cancellable | None = None
 ) -> str: ...
+@overload
+def dbus_address_get_stream(
+    address: str, cancellable: Cancellable | None = None
+) -> _gi.Async[tuple[IOStream, str | None]]: ...
+@overload
+def dbus_address_get_stream(
+    address: str,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+    *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
 def dbus_address_get_stream(
     address: str,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
-    *user_data: Unpack[_DataTs],
+    *,
+    callback: AsyncReadyCallback[None] | None,
 ) -> None: ...
 def dbus_address_get_stream_finish(res: AsyncResult) -> tuple[IOStream, str | None]: ...
 def dbus_address_get_stream_sync(
@@ -337,21 +401,45 @@ def file_new_for_commandline_arg_and_cwd(arg: str, cwd: str) -> File: ...
 def file_new_for_path(path: str) -> File: ...
 def file_new_for_uri(uri: str) -> File: ...
 def file_new_tmp(tmpl: str | None = None) -> tuple[File, FileIOStream]: ...
+@overload
+def file_new_tmp_async(
+    tmpl: str | None, io_priority: int, cancellable: Cancellable | None = None
+) -> _gi.Async[tuple[File, FileIOStream]]: ...
+@overload
+def file_new_tmp_async(
+    tmpl: str | None,
+    io_priority: int,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+    *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
 def file_new_tmp_async(
     tmpl: str | None,
     io_priority: int,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
+    *,
+    callback: AsyncReadyCallback[None] | None,
+) -> None: ...
+@overload
+def file_new_tmp_dir_async(
+    tmpl: str | None, io_priority: int, cancellable: Cancellable | None = None
+) -> _gi.Async[File]: ...
+@overload
+def file_new_tmp_dir_async(
+    tmpl: str | None,
+    io_priority: int,
+    cancellable: Cancellable | None,
+    callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
     *user_data: Unpack[_DataTs],
 ) -> None: ...
+@overload
 def file_new_tmp_dir_async(
     tmpl: str | None,
     io_priority: int,
     cancellable: Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
-    *user_data: Unpack[_DataTs],
+    *,
+    callback: AsyncReadyCallback[None] | None,
 ) -> None: ...
 def file_new_tmp_dir_finish(result: AsyncResult) -> File: ...
 def file_new_tmp_finish(result: AsyncResult) -> tuple[File, FileIOStream]: ...
@@ -742,26 +830,55 @@ class AppInfo(GObject.GInterface, Protocol):
     def get_default_for_type(
         content_type: str, must_support_uris: bool
     ) -> AppInfo | None: ...
+    @overload
     @staticmethod
     def get_default_for_type_async(
         content_type: str,
         must_support_uris: bool,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[AppInfo]: ...
+    @overload
+    @staticmethod
+    def get_default_for_type_async(
+        content_type: str,
+        must_support_uris: bool,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def get_default_for_type_async(
+        content_type: str,
+        must_support_uris: bool,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @staticmethod
     def get_default_for_type_finish(result: AsyncResult) -> AppInfo: ...
     @staticmethod
     def get_default_for_uri_scheme(uri_scheme: str) -> AppInfo | None: ...
+    @overload
+    @staticmethod
+    def get_default_for_uri_scheme_async(
+        uri_scheme: str, cancellable: Cancellable | None = None
+    ) -> _gi.Async[AppInfo]: ...
+    @overload
+    @staticmethod
+    def get_default_for_uri_scheme_async(
+        uri_scheme: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     @staticmethod
     def get_default_for_uri_scheme_async(
         uri_scheme: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @staticmethod
     def get_default_for_uri_scheme_finish(result: AsyncResult) -> AppInfo: ...
@@ -783,28 +900,60 @@ class AppInfo(GObject.GInterface, Protocol):
     def launch_default_for_uri(
         uri: str, context: AppLaunchContext | None = None
     ) -> bool: ...
+    @overload
     @staticmethod
     def launch_default_for_uri_async(
         uri: str,
         context: AppLaunchContext | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    @staticmethod
+    def launch_default_for_uri_async(
+        uri: str,
+        context: AppLaunchContext | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def launch_default_for_uri_async(
+        uri: str,
+        context: AppLaunchContext | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @staticmethod
     def launch_default_for_uri_finish(result: AsyncResult) -> bool: ...
     def launch_uris(
         self, uris: list[str] | None = None, context: AppLaunchContext | None = None
     ) -> bool: ...
+    @overload
     def launch_uris_async(
         self,
         uris: list[str] | None = None,
         context: AppLaunchContext | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def launch_uris_async(
+        self,
+        uris: list[str] | None,
+        context: AppLaunchContext | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[AppInfo, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def launch_uris_async(
+        self,
+        uris: list[str] | None = None,
+        context: AppLaunchContext | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[AppInfo] | None,
     ) -> None: ...
     def launch_uris_finish(self, result: AsyncResult) -> bool: ...
     def remove_supports_type(self, content_type: str) -> bool: ...
@@ -1297,13 +1446,25 @@ class AsyncInitable(GObject.GInterface, Protocol):
     Signals from GObject:
       notify (GParam)
     """
+    @overload
+    def init_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def init_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[AsyncInitable, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def init_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[AsyncInitable] | None,
     ) -> None: ...
     def init_finish(self, res: AsyncResult) -> bool: ...
     def new_finish(self, res: AsyncResult) -> GObject.Object: ...
@@ -1425,14 +1586,27 @@ class BufferedInputStream(FilterInputStream, Seekable):
     ) -> None: ...
     def do_fill_finish(self, result: AsyncResult) -> int: ...
     def fill(self, count: int, cancellable: Cancellable | None = None) -> int: ...
+    @overload
+    def fill_async(
+        self, count: int, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[int]: ...
+    @overload
+    def fill_async(
+        self,
+        count: int,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[BufferedInputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def fill_async(
         self,
         count: int,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[BufferedInputStream] | None,
     ) -> None: ...
     def fill_finish(self, result: AsyncResult) -> int: ...
     def get_available(self) -> int: ...
@@ -2022,6 +2196,7 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         ],
         *user_data: Unpack[_DataTs],
     ) -> int: ...
+    @overload
     def call(
         self,
         bus_name: str | None,
@@ -2033,9 +2208,36 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         flags: _DBusCallFlagsValueType,
         timeout_msec: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[GLib.Variant]: ...
+    @overload
+    def call(
+        self,
+        bus_name: str | None,
+        object_path: str,
+        interface_name: str,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        reply_type: GLib.VariantType | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DBusConnection, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def call(
+        self,
+        bus_name: str | None,
+        object_path: str,
+        interface_name: str,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        reply_type: GLib.VariantType | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[DBusConnection] | None,
     ) -> None: ...
     def call_finish(self, res: AsyncResult) -> GLib.Variant: ...
     def call_sync(
@@ -2050,6 +2252,7 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         timeout_msec: int,
         cancellable: Cancellable | None = None,
     ) -> GLib.Variant: ...
+    @overload
     def call_with_unix_fd_list(
         self,
         bus_name: str | None,
@@ -2062,9 +2265,38 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         timeout_msec: int,
         fd_list: UnixFDList | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[GLib.Variant, UnixFDList | None]]: ...
+    @overload
+    def call_with_unix_fd_list(
+        self,
+        bus_name: str | None,
+        object_path: str,
+        interface_name: str,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        reply_type: GLib.VariantType | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        fd_list: UnixFDList | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DBusConnection, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def call_with_unix_fd_list(
+        self,
+        bus_name: str | None,
+        object_path: str,
+        interface_name: str,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        reply_type: GLib.VariantType | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        fd_list: UnixFDList | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[DBusConnection] | None,
     ) -> None: ...
     def call_with_unix_fd_list_finish(
         self, res: AsyncResult
@@ -2082,12 +2314,21 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         fd_list: UnixFDList | None = None,
         cancellable: Cancellable | None = None,
     ) -> tuple[GLib.Variant, UnixFDList | None]: ...
+    @overload
+    def close(self, cancellable: Cancellable | None = None) -> _gi.Async[bool]: ...
+    @overload
+    def close(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DBusConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def close(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[DBusConnection] | None,
     ) -> None: ...
     def close_finish(self, res: AsyncResult) -> bool: ...
     def close_sync(self, cancellable: Cancellable | None = None) -> bool: ...
@@ -2103,12 +2344,21 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         self, object_path: str, action_group: ActionGroup
     ) -> int: ...
     def export_menu_model(self, object_path: str, menu: MenuModel) -> int: ...
+    @overload
+    def flush(self, cancellable: Cancellable | None = None) -> _gi.Async[bool]: ...
+    @overload
+    def flush(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DBusConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def flush(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[DBusConnection] | None,
     ) -> None: ...
     def flush_finish(self, res: AsyncResult) -> bool: ...
     def flush_sync(self, cancellable: Cancellable | None = None) -> bool: ...
@@ -2121,6 +2371,7 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
     def get_stream(self) -> IOStream: ...
     def get_unique_name(self) -> str | None: ...
     def is_closed(self) -> bool: ...
+    @overload
     @staticmethod
     def new(
         stream: IOStream,
@@ -2128,21 +2379,58 @@ class DBusConnection(GObject.Object, AsyncInitable, Initable):
         flags: _DBusConnectionFlagsValueType,
         observer: DBusAuthObserver | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[DBusConnection]: ...
+    @overload
+    @staticmethod
+    def new(
+        stream: IOStream,
+        guid: str | None,
+        flags: _DBusConnectionFlagsValueType,
+        observer: DBusAuthObserver | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new(
+        stream: IOStream,
+        guid: str | None,
+        flags: _DBusConnectionFlagsValueType,
+        observer: DBusAuthObserver | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_finish(cls, res: AsyncResult) -> DBusConnection: ...
+    @overload
     @staticmethod
     def new_for_address(
         address: str,
         flags: _DBusConnectionFlagsValueType,
         observer: DBusAuthObserver | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[DBusConnection]: ...
+    @overload
+    @staticmethod
+    def new_for_address(
+        address: str,
+        flags: _DBusConnectionFlagsValueType,
+        observer: DBusAuthObserver | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new_for_address(
+        address: str,
+        flags: _DBusConnectionFlagsValueType,
+        observer: DBusAuthObserver | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_for_address_finish(cls, res: AsyncResult) -> DBusConnection: ...
@@ -2778,6 +3066,7 @@ class DBusObjectManagerClient(
     def get_flags(self) -> DBusObjectManagerClientFlags: ...
     def get_name(self) -> str: ...
     def get_name_owner(self) -> str | None: ...
+    @overload
     @staticmethod
     def new(
         connection: DBusConnection,
@@ -2790,12 +3079,42 @@ class DBusObjectManagerClient(
         | None = None,
         get_proxy_type_user_data: Any | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[DBusObjectManagerClient]: ...
+    @overload
+    @staticmethod
+    def new(
+        connection: DBusConnection,
+        flags: _DBusObjectManagerClientFlagsValueType,
+        name: str,
+        object_path: str,
+        get_proxy_type_func: Callable[
+            [DBusObjectManagerClient, str, str | None, Any | None], type[Any]
+        ]
+        | None,
+        get_proxy_type_user_data: Any | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new(
+        connection: DBusConnection,
+        flags: _DBusObjectManagerClientFlagsValueType,
+        name: str,
+        object_path: str,
+        get_proxy_type_func: Callable[
+            [DBusObjectManagerClient, str, str | None, Any | None], type[Any]
+        ]
+        | None = None,
+        get_proxy_type_user_data: Any | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_finish(cls, res: AsyncResult) -> DBusObjectManagerClient: ...
+    @overload
     @staticmethod
     def new_for_bus(
         bus_type: _BusTypeValueType,
@@ -2808,9 +3127,38 @@ class DBusObjectManagerClient(
         | None = None,
         get_proxy_type_user_data: Any | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[DBusObjectManagerClient]: ...
+    @overload
+    @staticmethod
+    def new_for_bus(
+        bus_type: _BusTypeValueType,
+        flags: _DBusObjectManagerClientFlagsValueType,
+        name: str,
+        object_path: str,
+        get_proxy_type_func: Callable[
+            [DBusObjectManagerClient, str, str | None, Any | None], type[Any]
+        ]
+        | None,
+        get_proxy_type_user_data: Any | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new_for_bus(
+        bus_type: _BusTypeValueType,
+        flags: _DBusObjectManagerClientFlagsValueType,
+        name: str,
+        object_path: str,
+        get_proxy_type_func: Callable[
+            [DBusObjectManagerClient, str, str | None, Any | None], type[Any]
+        ]
+        | None = None,
+        get_proxy_type_user_data: Any | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_for_bus_finish(cls, res: AsyncResult) -> DBusObjectManagerClient: ...
@@ -3257,6 +3605,7 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
         g_name: str | None = ...,
         g_object_path: str | None = ...,
     ) -> None: ...
+    @overload
     def call(
         self,
         method_name: str,
@@ -3264,9 +3613,28 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
         flags: _DBusCallFlagsValueType,
         timeout_msec: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[GLib.Variant]: ...
+    @overload
+    def call(
+        self,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DBusProxy, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def call(
+        self,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[DBusProxy] | None,
     ) -> None: ...
     def call_finish(self, res: AsyncResult) -> GLib.Variant: ...
     def call_sync(
@@ -3277,6 +3645,7 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
         timeout_msec: int,
         cancellable: Cancellable | None = None,
     ) -> GLib.Variant: ...
+    @overload
     def call_with_unix_fd_list(
         self,
         method_name: str,
@@ -3285,9 +3654,30 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
         timeout_msec: int,
         fd_list: UnixFDList | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[GLib.Variant, UnixFDList | None]]: ...
+    @overload
+    def call_with_unix_fd_list(
+        self,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        fd_list: UnixFDList | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DBusProxy, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def call_with_unix_fd_list(
+        self,
+        method_name: str,
+        parameters: GLib.Variant | None,
+        flags: _DBusCallFlagsValueType,
+        timeout_msec: int,
+        fd_list: UnixFDList | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[DBusProxy] | None,
     ) -> None: ...
     def call_with_unix_fd_list_finish(
         self, res: AsyncResult
@@ -3317,6 +3707,7 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
     def get_name(self) -> str | None: ...
     def get_name_owner(self) -> str | None: ...
     def get_object_path(self) -> str: ...
+    @overload
     @staticmethod
     def new(
         connection: DBusConnection,
@@ -3326,12 +3717,36 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
         object_path: str,
         interface_name: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[DBusProxy]: ...
+    @overload
+    @staticmethod
+    def new(
+        connection: DBusConnection,
+        flags: _DBusProxyFlagsValueType,
+        info: DBusInterfaceInfo | None,
+        name: str | None,
+        object_path: str,
+        interface_name: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new(
+        connection: DBusConnection,
+        flags: _DBusProxyFlagsValueType,
+        info: DBusInterfaceInfo | None,
+        name: str | None,
+        object_path: str,
+        interface_name: str,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_finish(cls, res: AsyncResult) -> DBusProxy: ...
+    @overload
     @staticmethod
     def new_for_bus(
         bus_type: _BusTypeValueType,
@@ -3341,9 +3756,32 @@ class DBusProxy(GObject.Object, AsyncInitable, DBusInterface, Initable):
         object_path: str,
         interface_name: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[DBusProxy]: ...
+    @overload
+    @staticmethod
+    def new_for_bus(
+        bus_type: _BusTypeValueType,
+        flags: _DBusProxyFlagsValueType,
+        info: DBusInterfaceInfo | None,
+        name: str,
+        object_path: str,
+        interface_name: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new_for_bus(
+        bus_type: _BusTypeValueType,
+        flags: _DBusProxyFlagsValueType,
+        info: DBusInterfaceInfo | None,
+        name: str,
+        object_path: str,
+        interface_name: str,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @classmethod
     def new_for_bus_finish(cls, res: AsyncResult) -> DBusProxy: ...
@@ -3567,13 +4005,25 @@ class DataInputStream(BufferedInputStream):
     def read_line(
         self, cancellable: Cancellable | None = None
     ) -> tuple[bytes, int]: ...
+    @overload
+    def read_line_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[bytes, int]]: ...
+    @overload
+    def read_line_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DataInputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def read_line_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[DataInputStream] | None,
     ) -> None: ...
     def read_line_finish(self, result: AsyncResult) -> tuple[bytes, int]: ...
     def read_line_finish_utf8(self, result: AsyncResult) -> tuple[str | None, int]: ...
@@ -3586,14 +4036,27 @@ class DataInputStream(BufferedInputStream):
     def read_until(
         self, stop_chars: str, cancellable: Cancellable | None = None
     ) -> tuple[str, int]: ...
+    @overload
+    def read_until_async(
+        self, stop_chars: str, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[str, int]]: ...
+    @overload
+    def read_until_async(
+        self,
+        stop_chars: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DataInputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def read_until_async(
         self,
         stop_chars: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[DataInputStream] | None,
     ) -> None: ...
     def read_until_finish(self, result: AsyncResult) -> tuple[str, int]: ...
     def read_upto(
@@ -3602,15 +4065,33 @@ class DataInputStream(BufferedInputStream):
         stop_chars_len: int,
         cancellable: Cancellable | None = None,
     ) -> tuple[str, int]: ...
+    @overload
     def read_upto_async(
         self,
         stop_chars: str,
         stop_chars_len: int,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[str, int]]: ...
+    @overload
+    def read_upto_async(
+        self,
+        stop_chars: str,
+        stop_chars_len: int,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DataInputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def read_upto_async(
+        self,
+        stop_chars: str,
+        stop_chars_len: int,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[DataInputStream] | None,
     ) -> None: ...
     def read_upto_finish(self, result: AsyncResult) -> tuple[str, int]: ...
     def set_byte_order(self, order: _DataStreamByteOrderValueType) -> None: ...
@@ -3864,23 +4345,51 @@ class Drive(GObject.GInterface, Protocol):
     def can_start(self) -> bool: ...
     def can_start_degraded(self) -> bool: ...
     def can_stop(self) -> bool: ...
+    @overload
+    def eject(
+        self, flags: _MountUnmountFlagsValueType, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Drive, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def eject(
         self,
         flags: _MountUnmountFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Drive] | None,
     ) -> None: ...
     def eject_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def eject_with_operation(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Drive, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def eject_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Drive] | None,
     ) -> None: ...
     def eject_with_operation_finish(self, result: AsyncResult) -> bool: ...
     def enumerate_identifiers(self) -> list[str]: ...
@@ -3896,32 +4405,75 @@ class Drive(GObject.GInterface, Protocol):
     def is_media_check_automatic(self) -> bool: ...
     def is_media_removable(self) -> bool: ...
     def is_removable(self) -> bool: ...
+    @overload
+    def poll_for_media(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def poll_for_media(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Drive, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def poll_for_media(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Drive] | None,
     ) -> None: ...
     def poll_for_media_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def start(
         self,
         flags: _DriveStartFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def start(
+        self,
+        flags: _DriveStartFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Drive, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def start(
+        self,
+        flags: _DriveStartFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Drive] | None,
+    ) -> None: ...
     def start_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def stop(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def stop(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Drive, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def stop(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Drive] | None,
     ) -> None: ...
     def stop_finish(self, result: AsyncResult) -> bool: ...
 
@@ -4093,13 +4645,25 @@ class DtlsConnection(GObject.GInterface, Protocol):
       notify (GParam)
     """
     def close(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def close_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def close_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DtlsConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def close_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[DtlsConnection] | None,
     ) -> None: ...
     def close_finish(self, result: AsyncResult) -> bool: ...
     def emit_accept_certificate(
@@ -4119,13 +4683,25 @@ class DtlsConnection(GObject.GInterface, Protocol):
     def get_rehandshake_mode(self) -> TlsRehandshakeMode: ...
     def get_require_close_notify(self) -> bool: ...
     def handshake(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def handshake_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def handshake_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DtlsConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def handshake_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[DtlsConnection] | None,
     ) -> None: ...
     def handshake_finish(self, result: AsyncResult) -> bool: ...
     def set_advertised_protocols(
@@ -4142,15 +4718,33 @@ class DtlsConnection(GObject.GInterface, Protocol):
         shutdown_write: bool,
         cancellable: Cancellable | None = None,
     ) -> bool: ...
+    @overload
     def shutdown_async(
         self,
         shutdown_read: bool,
         shutdown_write: bool,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def shutdown_async(
+        self,
+        shutdown_read: bool,
+        shutdown_write: bool,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[DtlsConnection, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def shutdown_async(
+        self,
+        shutdown_read: bool,
+        shutdown_write: bool,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[DtlsConnection] | None,
     ) -> None: ...
     def shutdown_finish(self, result: AsyncResult) -> bool: ...
 
@@ -4343,14 +4937,30 @@ class File(GObject.GInterface, Protocol):
     def append_to(
         self, flags: _FileCreateFlagsValueType, cancellable: Cancellable | None = None
     ) -> FileOutputStream: ...
+    @overload
     def append_to_async(
         self,
         flags: _FileCreateFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileOutputStream]: ...
+    @overload
+    def append_to_async(
+        self,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def append_to_async(
+        self,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def append_to_finish(self, res: AsyncResult) -> FileOutputStream: ...
     def build_attribute_list_for_copy(
@@ -4383,57 +4993,129 @@ class File(GObject.GInterface, Protocol):
     def create(
         self, flags: _FileCreateFlagsValueType, cancellable: Cancellable | None = None
     ) -> FileOutputStream: ...
+    @overload
     def create_async(
         self,
         flags: _FileCreateFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileOutputStream]: ...
+    @overload
+    def create_async(
+        self,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def create_async(
+        self,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def create_finish(self, res: AsyncResult) -> FileOutputStream: ...
     def create_readwrite(
         self, flags: _FileCreateFlagsValueType, cancellable: Cancellable | None = None
     ) -> FileIOStream: ...
+    @overload
     def create_readwrite_async(
         self,
         flags: _FileCreateFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileIOStream]: ...
+    @overload
+    def create_readwrite_async(
+        self,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def create_readwrite_async(
+        self,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def create_readwrite_finish(self, res: AsyncResult) -> FileIOStream: ...
     def delete(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def delete_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def delete_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def delete_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def delete_finish(self, result: AsyncResult) -> bool: ...
     def dup(self) -> File: ...
+    @overload
+    def eject_mountable(
+        self, flags: _MountUnmountFlagsValueType, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject_mountable(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def eject_mountable(
         self,
         flags: _MountUnmountFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def eject_mountable_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def eject_mountable_with_operation(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject_mountable_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def eject_mountable_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def eject_mountable_with_operation_finish(self, result: AsyncResult) -> bool: ...
     def enumerate_children(
@@ -4442,26 +5124,56 @@ class File(GObject.GInterface, Protocol):
         flags: _FileQueryInfoFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> FileEnumerator: ...
+    @overload
     def enumerate_children_async(
         self,
         attributes: str,
         flags: _FileQueryInfoFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileEnumerator]: ...
+    @overload
+    def enumerate_children_async(
+        self,
+        attributes: str,
+        flags: _FileQueryInfoFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def enumerate_children_async(
+        self,
+        attributes: str,
+        flags: _FileQueryInfoFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def enumerate_children_finish(self, res: AsyncResult) -> FileEnumerator: ...
     def equal(self, file2: File) -> bool: ...
     def find_enclosing_mount(self, cancellable: Cancellable | None = None) -> Mount: ...
+    @overload
+    def find_enclosing_mount_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[Mount]: ...
+    @overload
+    def find_enclosing_mount_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def find_enclosing_mount_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def find_enclosing_mount_finish(self, res: AsyncResult) -> Mount: ...
     def get_basename(self) -> str | None: ...
@@ -4481,12 +5193,23 @@ class File(GObject.GInterface, Protocol):
     def load_bytes(
         self, cancellable: Cancellable | None = None
     ) -> tuple[GLib.Bytes, str | None]: ...
+    @overload
+    def load_bytes_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[GLib.Bytes, str | None]]: ...
+    @overload
+    def load_bytes_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def load_bytes_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def load_bytes_finish(
         self, result: AsyncResult
@@ -4494,12 +5217,23 @@ class File(GObject.GInterface, Protocol):
     def load_contents(
         self, cancellable: Cancellable | None = None
     ) -> tuple[bool, bytes, str | None]: ...
+    @overload
+    def load_contents_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[bool, bytes, str | None]]: ...
+    @overload
+    def load_contents_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def load_contents_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def load_contents_finish(
         self, res: AsyncResult
@@ -4508,13 +5242,25 @@ class File(GObject.GInterface, Protocol):
         self, res: AsyncResult
     ) -> tuple[bool, bytes, str | None]: ...
     def make_directory(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def make_directory_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def make_directory_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def make_directory_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def make_directory_finish(self, result: AsyncResult) -> bool: ...
     def make_directory_with_parents(
@@ -4523,14 +5269,30 @@ class File(GObject.GInterface, Protocol):
     def make_symbolic_link(
         self, symlink_value: str, cancellable: Cancellable | None = None
     ) -> bool: ...
+    @overload
     def make_symbolic_link_async(
         self,
         symlink_value: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def make_symbolic_link_async(
+        self,
+        symlink_value: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def make_symbolic_link_async(
+        self,
+        symlink_value: str,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def make_symbolic_link_finish(self, result: AsyncResult) -> bool: ...
     def measure_disk_usage(
@@ -4553,24 +5315,56 @@ class File(GObject.GInterface, Protocol):
     def monitor_file(
         self, flags: _FileMonitorFlagsValueType, cancellable: Cancellable | None = None
     ) -> FileMonitor: ...
+    @overload
     def mount_enclosing_volume(
         self,
         flags: _MountMountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def mount_enclosing_volume(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def mount_enclosing_volume(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
+    ) -> None: ...
     def mount_enclosing_volume_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def mount_mountable(
         self,
         flags: _MountMountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[File]: ...
+    @overload
+    def mount_mountable(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def mount_mountable(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def mount_mountable_finish(self, result: AsyncResult) -> File: ...
     def move(
@@ -4603,23 +5397,51 @@ class File(GObject.GInterface, Protocol):
     def new_for_uri(uri: str) -> File: ...
     @staticmethod
     def new_tmp(tmpl: str | None = None) -> tuple[File, FileIOStream]: ...
+    @overload
+    @staticmethod
+    def new_tmp_async(
+        tmpl: str | None, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[File, FileIOStream]]: ...
+    @overload
+    @staticmethod
+    def new_tmp_async(
+        tmpl: str | None,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     @staticmethod
     def new_tmp_async(
         tmpl: str | None,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+        *,
+        callback: AsyncReadyCallback[None] | None,
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def new_tmp_dir_async(
+        tmpl: str | None, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[File]: ...
+    @overload
+    @staticmethod
+    def new_tmp_dir_async(
+        tmpl: str | None,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
     @staticmethod
     def new_tmp_dir_async(
         tmpl: str | None,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[None] | None,
     ) -> None: ...
     @staticmethod
     def new_tmp_dir_finish(result: AsyncResult) -> File: ...
@@ -4628,36 +5450,71 @@ class File(GObject.GInterface, Protocol):
     def open_readwrite(
         self, cancellable: Cancellable | None = None
     ) -> FileIOStream: ...
+    @overload
+    def open_readwrite_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[FileIOStream]: ...
+    @overload
+    def open_readwrite_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def open_readwrite_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def open_readwrite_finish(self, res: AsyncResult) -> FileIOStream: ...
     @staticmethod
     def parse_name(parse_name: str) -> File: ...
     def peek_path(self) -> str | None: ...
+    @overload
+    def poll_mountable(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def poll_mountable(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def poll_mountable(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def poll_mountable_finish(self, result: AsyncResult) -> bool: ...
     def query_default_handler(
         self, cancellable: Cancellable | None = None
     ) -> AppInfo: ...
+    @overload
+    def query_default_handler_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[AppInfo]: ...
+    @overload
+    def query_default_handler_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def query_default_handler_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def query_default_handler_finish(self, result: AsyncResult) -> AppInfo: ...
     def query_exists(self, cancellable: Cancellable | None = None) -> bool: ...
@@ -4669,14 +5526,27 @@ class File(GObject.GInterface, Protocol):
     def query_filesystem_info(
         self, attributes: str, cancellable: Cancellable | None = None
     ) -> FileInfo: ...
+    @overload
+    def query_filesystem_info_async(
+        self, attributes: str, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[FileInfo]: ...
+    @overload
+    def query_filesystem_info_async(
+        self,
+        attributes: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def query_filesystem_info_async(
         self,
         attributes: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def query_filesystem_info_finish(self, res: AsyncResult) -> FileInfo: ...
     def query_info(
@@ -4685,15 +5555,33 @@ class File(GObject.GInterface, Protocol):
         flags: _FileQueryInfoFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> FileInfo: ...
+    @overload
     def query_info_async(
         self,
         attributes: str,
         flags: _FileQueryInfoFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileInfo]: ...
+    @overload
+    def query_info_async(
+        self,
+        attributes: str,
+        flags: _FileQueryInfoFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def query_info_async(
+        self,
+        attributes: str,
+        flags: _FileQueryInfoFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def query_info_finish(self, res: AsyncResult) -> FileInfo: ...
     def query_settable_attributes(
@@ -4703,13 +5591,25 @@ class File(GObject.GInterface, Protocol):
         self, cancellable: Cancellable | None = None
     ) -> FileAttributeInfoList: ...
     def read(self, cancellable: Cancellable | None = None) -> FileInputStream: ...
+    @overload
+    def read_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[FileInputStream]: ...
+    @overload
+    def read_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def read_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def read_finish(self, res: AsyncResult) -> FileInputStream: ...
     def replace(
@@ -4719,6 +5619,7 @@ class File(GObject.GInterface, Protocol):
         flags: _FileCreateFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> FileOutputStream: ...
+    @overload
     def replace_async(
         self,
         etag: str | None,
@@ -4726,9 +5627,28 @@ class File(GObject.GInterface, Protocol):
         flags: _FileCreateFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileOutputStream]: ...
+    @overload
+    def replace_async(
+        self,
+        etag: str | None,
+        make_backup: bool,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def replace_async(
+        self,
+        etag: str | None,
+        make_backup: bool,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def replace_contents(
         self,
@@ -4738,6 +5658,7 @@ class File(GObject.GInterface, Protocol):
         flags: _FileCreateFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> tuple[bool, str | None]: ...
+    @overload
     def replace_contents_async(
         self,
         contents: Sequence[int],
@@ -4745,9 +5666,28 @@ class File(GObject.GInterface, Protocol):
         make_backup: bool,
         flags: _FileCreateFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, str | None]]: ...
+    @overload
+    def replace_contents_async(
+        self,
+        contents: Sequence[int],
+        etag: str | None,
+        make_backup: bool,
+        flags: _FileCreateFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def replace_contents_async(
+        self,
+        contents: Sequence[int],
+        etag: str | None,
+        make_backup: bool,
+        flags: _FileCreateFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def replace_contents_bytes_async(
         self,
@@ -4769,6 +5709,7 @@ class File(GObject.GInterface, Protocol):
         flags: _FileCreateFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> FileIOStream: ...
+    @overload
     def replace_readwrite_async(
         self,
         etag: str | None,
@@ -4776,9 +5717,28 @@ class File(GObject.GInterface, Protocol):
         flags: _FileCreateFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[FileIOStream]: ...
+    @overload
+    def replace_readwrite_async(
+        self,
+        etag: str | None,
+        make_backup: bool,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def replace_readwrite_async(
+        self,
+        etag: str | None,
+        make_backup: bool,
+        flags: _FileCreateFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def replace_readwrite_finish(self, res: AsyncResult) -> FileIOStream: ...
     def resolve_relative_path(self, relative_path: str) -> File: ...
@@ -4832,15 +5792,33 @@ class File(GObject.GInterface, Protocol):
         flags: _FileQueryInfoFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> bool: ...
+    @overload
     def set_attributes_async(
         self,
         info: FileInfo,
         flags: _FileQueryInfoFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, FileInfo]]: ...
+    @overload
+    def set_attributes_async(
+        self,
+        info: FileInfo,
+        flags: _FileQueryInfoFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def set_attributes_async(
+        self,
+        info: FileInfo,
+        flags: _FileQueryInfoFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def set_attributes_finish(self, result: AsyncResult) -> tuple[bool, FileInfo]: ...
     def set_attributes_from_info(
@@ -4852,64 +5830,152 @@ class File(GObject.GInterface, Protocol):
     def set_display_name(
         self, display_name: str, cancellable: Cancellable | None = None
     ) -> File: ...
+    @overload
     def set_display_name_async(
         self,
         display_name: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[File]: ...
+    @overload
+    def set_display_name_async(
+        self,
+        display_name: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def set_display_name_async(
+        self,
+        display_name: str,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
+    ) -> None: ...
     def set_display_name_finish(self, res: AsyncResult) -> File: ...
+    @overload
     def start_mountable(
         self,
         flags: _DriveStartFlagsValueType,
         start_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def start_mountable(
+        self,
+        flags: _DriveStartFlagsValueType,
+        start_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def start_mountable(
+        self,
+        flags: _DriveStartFlagsValueType,
+        start_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
+    ) -> None: ...
     def start_mountable_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def stop_mountable(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def stop_mountable(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def stop_mountable(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def stop_mountable_finish(self, result: AsyncResult) -> bool: ...
     def supports_thread_contexts(self) -> bool: ...
     def trash(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def trash_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def trash_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def trash_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def trash_finish(self, result: AsyncResult) -> bool: ...
+    @overload
+    def unmount_mountable(
+        self, flags: _MountUnmountFlagsValueType, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def unmount_mountable(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def unmount_mountable(
         self,
         flags: _MountUnmountFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def unmount_mountable_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def unmount_mountable_with_operation(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def unmount_mountable_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[File, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def unmount_mountable_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[File] | None,
     ) -> None: ...
     def unmount_mountable_with_operation_finish(self, result: AsyncResult) -> bool: ...
 
@@ -5002,13 +6068,25 @@ class FileEnumerator(GObject.Object):
     # override
     def __next__(self) -> FileInfo: ...
     def close(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def close_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def close_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[FileEnumerator, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def close_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[FileEnumerator] | None,
     ) -> None: ...
     def close_finish(self, result: AsyncResult) -> bool: ...
     def do_close_async(
@@ -5040,14 +6118,27 @@ class FileEnumerator(GObject.Object):
         self, cancellable: Cancellable | None = None
     ) -> tuple[bool, FileInfo, File]: ...
     def next_file(self, cancellable: Cancellable | None = None) -> FileInfo | None: ...
+    @overload
+    def next_files_async(
+        self, num_files: int, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[list[FileInfo]]: ...
+    @overload
+    def next_files_async(
+        self,
+        num_files: int,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[FileEnumerator, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def next_files_async(
         self,
         num_files: int,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[FileEnumerator] | None,
     ) -> None: ...
     def next_files_finish(self, result: AsyncResult) -> list[FileInfo]: ...
     def set_pending(self, pending: bool) -> None: ...
@@ -5151,14 +6242,27 @@ class FileIOStream(IOStream, Seekable):
     def query_info(
         self, attributes: str, cancellable: Cancellable | None = None
     ) -> FileInfo: ...
+    @overload
+    def query_info_async(
+        self, attributes: str, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[FileInfo]: ...
+    @overload
+    def query_info_async(
+        self,
+        attributes: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[FileIOStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def query_info_async(
         self,
         attributes: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[FileIOStream] | None,
     ) -> None: ...
     def query_info_finish(self, result: AsyncResult) -> FileInfo: ...
 
@@ -6043,14 +7147,27 @@ class FileInputStream(InputStream, Seekable):
     def query_info(
         self, attributes: str, cancellable: Cancellable | None = None
     ) -> FileInfo: ...
+    @overload
+    def query_info_async(
+        self, attributes: str, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[FileInfo]: ...
+    @overload
+    def query_info_async(
+        self,
+        attributes: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[FileInputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def query_info_async(
         self,
         attributes: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[FileInputStream] | None,
     ) -> None: ...
     def query_info_finish(self, result: AsyncResult) -> FileInfo: ...
 
@@ -6205,14 +7322,27 @@ class FileOutputStream(OutputStream, Seekable):
     def query_info(
         self, attributes: str, cancellable: Cancellable | None = None
     ) -> FileInfo: ...
+    @overload
+    def query_info_async(
+        self, attributes: str, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[FileInfo]: ...
+    @overload
+    def query_info_async(
+        self,
+        attributes: str,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[FileOutputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def query_info_async(
         self,
         attributes: str,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[FileOutputStream] | None,
     ) -> None: ...
     def query_info_finish(self, result: AsyncResult) -> FileInfo: ...
 
@@ -6486,13 +7616,25 @@ class IOStream(GObject.Object):
     def priv(self) -> IOStreamPrivate: ...
     def clear_pending(self) -> None: ...
     def close(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def close_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def close_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[IOStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def close_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[IOStream] | None,
     ) -> None: ...
     def close_finish(self, result: AsyncResult) -> bool: ...
     def do_close_async(
@@ -6512,15 +7654,33 @@ class IOStream(GObject.Object):
     def has_pending(self) -> bool: ...
     def is_closed(self) -> bool: ...
     def set_pending(self) -> bool: ...
+    @overload
     def splice_async(
         self,
         stream2: IOStream,
         flags: _IOStreamSpliceFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def splice_async(
+        self,
+        stream2: IOStream,
+        flags: _IOStreamSpliceFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[IOStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def splice_async(
+        self,
+        stream2: IOStream,
+        flags: _IOStreamSpliceFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[IOStream] | None,
     ) -> None: ...
     @staticmethod
     def splice_finish(result: AsyncResult) -> bool: ...
@@ -6927,13 +8087,25 @@ class InputStream(GObject.Object):
     def priv(self) -> InputStreamPrivate: ...
     def clear_pending(self) -> None: ...
     def close(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def close_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def close_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[InputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def close_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[InputStream] | None,
     ) -> None: ...
     def close_finish(self, result: AsyncResult) -> bool: ...
     def do_close_async(
@@ -6995,27 +8167,53 @@ class InputStream(GObject.Object):
     def read_bytes(
         self, count: int, cancellable: Cancellable | None = None
     ) -> GLib.Bytes: ...
+    @overload
+    def read_bytes_async(
+        self, count: int, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[GLib.Bytes]: ...
+    @overload
+    def read_bytes_async(
+        self,
+        count: int,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[InputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def read_bytes_async(
         self,
         count: int,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[InputStream] | None,
     ) -> None: ...
     def read_bytes_finish(self, result: AsyncResult) -> GLib.Bytes: ...
     def read_finish(self, result: AsyncResult) -> int: ...
     def set_pending(self) -> bool: ...
     def skip(self, count: int, cancellable: Cancellable | None = None) -> int: ...
+    @overload
+    def skip_async(
+        self, count: int, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[int]: ...
+    @overload
+    def skip_async(
+        self,
+        count: int,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[InputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def skip_async(
         self,
         count: int,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[InputStream] | None,
     ) -> None: ...
     def skip_finish(self, result: AsyncResult) -> int: ...
 
@@ -7238,13 +8436,25 @@ class LoadableIcon(GObject.GInterface, Protocol):
     def load(
         self, size: int, cancellable: Cancellable | None = None
     ) -> tuple[InputStream, str]: ...
+    @overload
+    def load_async(
+        self, size: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[InputStream, str]]: ...
+    @overload
+    def load_async(
+        self,
+        size: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[LoadableIcon, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def load_async(
         self,
         size: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[LoadableIcon] | None,
     ) -> None: ...
     def load_finish(self, res: AsyncResult) -> tuple[InputStream, str]: ...
 
@@ -7670,23 +8880,51 @@ class Mount(GObject.GInterface, Protocol):
     """
     def can_eject(self) -> bool: ...
     def can_unmount(self) -> bool: ...
+    @overload
+    def eject(
+        self, flags: _MountUnmountFlagsValueType, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Mount, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def eject(
         self,
         flags: _MountUnmountFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Mount] | None,
     ) -> None: ...
     def eject_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def eject_with_operation(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Mount, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def eject_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Mount] | None,
     ) -> None: ...
     def eject_with_operation_finish(self, result: AsyncResult) -> bool: ...
     def get_default_location(self) -> File: ...
@@ -7698,47 +8936,103 @@ class Mount(GObject.GInterface, Protocol):
     def get_symbolic_icon(self) -> Icon: ...
     def get_uuid(self) -> str | None: ...
     def get_volume(self) -> Volume | None: ...
+    @overload
+    def guess_content_type(
+        self, force_rescan: bool, cancellable: Cancellable | None = None
+    ) -> _gi.Async[list[str]]: ...
+    @overload
+    def guess_content_type(
+        self,
+        force_rescan: bool,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Mount, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def guess_content_type(
         self,
         force_rescan: bool,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Mount] | None,
     ) -> None: ...
     def guess_content_type_finish(self, result: AsyncResult) -> list[str]: ...
     def guess_content_type_sync(
         self, force_rescan: bool, cancellable: Cancellable | None = None
     ) -> list[str]: ...
     def is_shadowed(self) -> bool: ...
+    @overload
     def remount(
         self,
         flags: _MountMountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def remount(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Mount, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def remount(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Mount] | None,
     ) -> None: ...
     def remount_finish(self, result: AsyncResult) -> bool: ...
     def shadow(self) -> None: ...
+    @overload
+    def unmount(
+        self, flags: _MountUnmountFlagsValueType, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def unmount(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Mount, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def unmount(
         self,
         flags: _MountUnmountFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Mount] | None,
     ) -> None: ...
     def unmount_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def unmount_with_operation(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def unmount_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Mount, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def unmount_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Mount] | None,
     ) -> None: ...
     def unmount_with_operation_finish(self, result: AsyncResult) -> bool: ...
     def unshadow(self) -> None: ...
@@ -8174,13 +9468,25 @@ class NetworkMonitor(GObject.GInterface, Protocol):
     def can_reach(
         self, connectable: SocketConnectable, cancellable: Cancellable | None = None
     ) -> bool: ...
+    @overload
+    def can_reach_async(
+        self, connectable: SocketConnectable, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def can_reach_async(
+        self,
+        connectable: SocketConnectable,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[NetworkMonitor, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def can_reach_async(
         self,
         connectable: SocketConnectable,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[NetworkMonitor] | None,
     ) -> None: ...
     def can_reach_finish(self, result: AsyncResult) -> bool: ...
     def get_connectivity(self) -> NetworkConnectivity: ...
@@ -8352,13 +9658,25 @@ class OutputStream(GObject.Object):
     def priv(self) -> OutputStreamPrivate: ...
     def clear_pending(self) -> None: ...
     def close(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def close_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def close_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def close_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
     ) -> None: ...
     def close_finish(self, result: AsyncResult) -> bool: ...
     def do_close_async(
@@ -8425,13 +9743,25 @@ class OutputStream(GObject.Object):
         self, vectors: Sequence[OutputVector], cancellable: Cancellable | None
     ) -> tuple[bool, int]: ...
     def flush(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def flush_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def flush_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def flush_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
     ) -> None: ...
     def flush_finish(self, result: AsyncResult) -> bool: ...
     def has_pending(self) -> bool: ...
@@ -8444,15 +9774,33 @@ class OutputStream(GObject.Object):
         flags: _OutputStreamSpliceFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> int: ...
+    @overload
     def splice_async(
         self,
         source: InputStream,
         flags: _OutputStreamSpliceFlagsValueType,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[int]: ...
+    @overload
+    def splice_async(
+        self,
+        source: InputStream,
+        flags: _OutputStreamSpliceFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def splice_async(
+        self,
+        source: InputStream,
+        flags: _OutputStreamSpliceFlagsValueType,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
     ) -> None: ...
     def splice_finish(self, result: AsyncResult) -> int: ...
     def write(
@@ -8461,36 +9809,84 @@ class OutputStream(GObject.Object):
     def write_all(
         self, buffer: Sequence[int], cancellable: Cancellable | None = None
     ) -> tuple[bool, int]: ...
+    @overload
     def write_all_async(
         self,
         buffer: Sequence[int],
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, int]]: ...
+    @overload
+    def write_all_async(
+        self,
+        buffer: Sequence[int],
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def write_all_async(
+        self,
+        buffer: Sequence[int],
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
+    ) -> None: ...
     def write_all_finish(self, result: AsyncResult) -> tuple[bool, int]: ...
+    @overload
     def write_async(
         self,
         buffer: Sequence[int],
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[int]: ...
+    @overload
+    def write_async(
+        self,
+        buffer: Sequence[int],
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def write_async(
+        self,
+        buffer: Sequence[int],
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
     ) -> None: ...
     def write_bytes(
         self, bytes: GLib.Bytes, cancellable: Cancellable | None = None
     ) -> int: ...
+    @overload
     def write_bytes_async(
         self,
         bytes: GLib.Bytes,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[int]: ...
+    @overload
+    def write_bytes_async(
+        self,
+        bytes: GLib.Bytes,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def write_bytes_async(
+        self,
+        bytes: GLib.Bytes,
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
     ) -> None: ...
     def write_bytes_finish(self, result: AsyncResult) -> int: ...
     def write_finish(self, result: AsyncResult) -> int: ...
@@ -8500,24 +9896,56 @@ class OutputStream(GObject.Object):
     def writev_all(
         self, vectors: Sequence[OutputVector], cancellable: Cancellable | None = None
     ) -> tuple[bool, int]: ...
+    @overload
     def writev_all_async(
         self,
         vectors: Sequence[OutputVector],
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, int]]: ...
+    @overload
+    def writev_all_async(
+        self,
+        vectors: Sequence[OutputVector],
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def writev_all_async(
+        self,
+        vectors: Sequence[OutputVector],
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
+    ) -> None: ...
     def writev_all_finish(self, result: AsyncResult) -> tuple[bool, int]: ...
+    @overload
     def writev_async(
         self,
         vectors: Sequence[OutputVector],
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, int]]: ...
+    @overload
+    def writev_async(
+        self,
+        vectors: Sequence[OutputVector],
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[OutputStream, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def writev_async(
+        self,
+        vectors: Sequence[OutputVector],
+        io_priority: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[OutputStream] | None,
     ) -> None: ...
     def writev_finish(self, result: AsyncResult) -> tuple[bool, int]: ...
 
@@ -8692,12 +10120,23 @@ class Permission(GObject.Object):
     @property
     def priv(self) -> PermissionPrivate: ...
     def acquire(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def acquire_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def acquire_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Permission, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def acquire_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Permission] | None,
     ) -> None: ...
     def acquire_finish(self, result: AsyncResult) -> bool: ...
     def do_acquire(self, cancellable: Cancellable | None) -> bool: ...
@@ -8725,12 +10164,23 @@ class Permission(GObject.Object):
         self, allowed: bool, can_acquire: bool, can_release: bool
     ) -> None: ...
     def release(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def release_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def release_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Permission, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def release_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Permission] | None,
     ) -> None: ...
     def release_finish(self, result: AsyncResult) -> bool: ...
 
@@ -8953,14 +10403,30 @@ class Proxy(GObject.GInterface, Protocol):
         proxy_address: ProxyAddress,
         cancellable: Cancellable | None = None,
     ) -> IOStream: ...
+    @overload
     def connect_async(
         self,
         connection: IOStream,
         proxy_address: ProxyAddress,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[IOStream]: ...
+    @overload
+    def connect_async(
+        self,
+        connection: IOStream,
+        proxy_address: ProxyAddress,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Proxy, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def connect_async(
+        self,
+        connection: IOStream,
+        proxy_address: ProxyAddress,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Proxy] | None,
     ) -> None: ...
     def connect_finish(self, result: AsyncResult) -> IOStream: ...
     @staticmethod
@@ -9169,13 +10635,25 @@ class ProxyResolver(GObject.GInterface, Protocol):
     def get_default() -> ProxyResolver: ...
     def is_supported(self) -> bool: ...
     def lookup(self, uri: str, cancellable: Cancellable | None = None) -> list[str]: ...
+    @overload
+    def lookup_async(
+        self, uri: str, cancellable: Cancellable | None = None
+    ) -> _gi.Async[list[str]]: ...
+    @overload
+    def lookup_async(
+        self,
+        uri: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[ProxyResolver, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def lookup_async(
         self,
         uri: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[ProxyResolver] | None,
     ) -> None: ...
     def lookup_finish(self, result: AsyncResult) -> list[str]: ...
 
@@ -9353,25 +10831,49 @@ class Resolver(GObject.Object):
     def lookup_by_address(
         self, address: InetAddress, cancellable: Cancellable | None = None
     ) -> str: ...
+    @overload
+    def lookup_by_address_async(
+        self, address: InetAddress, cancellable: Cancellable | None = None
+    ) -> _gi.Async[str]: ...
+    @overload
+    def lookup_by_address_async(
+        self,
+        address: InetAddress,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Resolver, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def lookup_by_address_async(
         self,
         address: InetAddress,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Resolver] | None,
     ) -> None: ...
     def lookup_by_address_finish(self, result: AsyncResult) -> str: ...
     def lookup_by_name(
         self, hostname: str, cancellable: Cancellable | None = None
     ) -> list[InetAddress]: ...
+    @overload
+    def lookup_by_name_async(
+        self, hostname: str, cancellable: Cancellable | None = None
+    ) -> _gi.Async[list[InetAddress]]: ...
+    @overload
+    def lookup_by_name_async(
+        self,
+        hostname: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Resolver, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def lookup_by_name_async(
         self,
         hostname: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Resolver] | None,
     ) -> None: ...
     def lookup_by_name_finish(self, result: AsyncResult) -> list[InetAddress]: ...
     def lookup_by_name_with_flags(
@@ -9380,14 +10882,30 @@ class Resolver(GObject.Object):
         flags: _ResolverNameLookupFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> list[InetAddress]: ...
+    @overload
     def lookup_by_name_with_flags_async(
         self,
         hostname: str,
         flags: _ResolverNameLookupFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[list[InetAddress]]: ...
+    @overload
+    def lookup_by_name_with_flags_async(
+        self,
+        hostname: str,
+        flags: _ResolverNameLookupFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Resolver, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def lookup_by_name_with_flags_async(
+        self,
+        hostname: str,
+        flags: _ResolverNameLookupFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Resolver] | None,
     ) -> None: ...
     def lookup_by_name_with_flags_finish(
         self, result: AsyncResult
@@ -9398,14 +10916,30 @@ class Resolver(GObject.Object):
         record_type: _ResolverRecordTypeValueType,
         cancellable: Cancellable | None = None,
     ) -> list[GLib.Variant]: ...
+    @overload
     def lookup_records_async(
         self,
         rrname: str,
         record_type: _ResolverRecordTypeValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[list[GLib.Variant]]: ...
+    @overload
+    def lookup_records_async(
+        self,
+        rrname: str,
+        record_type: _ResolverRecordTypeValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Resolver, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def lookup_records_async(
+        self,
+        rrname: str,
+        record_type: _ResolverRecordTypeValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Resolver] | None,
     ) -> None: ...
     def lookup_records_finish(self, result: AsyncResult) -> list[GLib.Variant]: ...
     def lookup_service(
@@ -9415,15 +10949,33 @@ class Resolver(GObject.Object):
         domain: str,
         cancellable: Cancellable | None = None,
     ) -> list[SrvTarget]: ...
+    @overload
     def lookup_service_async(
         self,
         service: str,
         protocol: str,
         domain: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[list[SrvTarget]]: ...
+    @overload
+    def lookup_service_async(
+        self,
+        service: str,
+        protocol: str,
+        domain: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Resolver, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def lookup_service_async(
+        self,
+        service: str,
+        protocol: str,
+        domain: str,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Resolver] | None,
     ) -> None: ...
     def lookup_service_finish(self, result: AsyncResult) -> list[SrvTarget]: ...
     def set_default(self) -> None: ...
@@ -10511,12 +12063,23 @@ class SocketAddressEnumerator(GObject.Object):
     ) -> None: ...
     def do_next_finish(self, result: AsyncResult) -> SocketAddress | None: ...
     def next(self, cancellable: Cancellable | None = None) -> SocketAddress | None: ...
+    @overload
+    def next_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[SocketAddress | None]: ...
+    @overload
+    def next_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketAddressEnumerator, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def next_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketAddressEnumerator] | None,
     ) -> None: ...
     def next_finish(self, result: AsyncResult) -> SocketAddress | None: ...
 
@@ -10644,13 +12207,25 @@ class SocketClient(GObject.Object):
     def connect(
         self, connectable: SocketConnectable, cancellable: Cancellable | None = None
     ) -> SocketConnection: ...
+    @overload
+    def connect_async(
+        self, connectable: SocketConnectable, cancellable: Cancellable | None = None
+    ) -> _gi.Async[SocketConnection]: ...
+    @overload
+    def connect_async(
+        self,
+        connectable: SocketConnectable,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketClient, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def connect_async(
         self,
         connectable: SocketConnectable,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketClient] | None,
     ) -> None: ...
     def connect_finish(self, result: AsyncResult) -> SocketConnection: ...
     def connect_to_host(
@@ -10659,40 +12234,82 @@ class SocketClient(GObject.Object):
         default_port: int,
         cancellable: Cancellable | None = None,
     ) -> SocketConnection: ...
+    @overload
     def connect_to_host_async(
         self,
         host_and_port: str,
         default_port: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[SocketConnection]: ...
+    @overload
+    def connect_to_host_async(
+        self,
+        host_and_port: str,
+        default_port: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketClient, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def connect_to_host_async(
+        self,
+        host_and_port: str,
+        default_port: int,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[SocketClient] | None,
     ) -> None: ...
     def connect_to_host_finish(self, result: AsyncResult) -> SocketConnection: ...
     def connect_to_service(
         self, domain: str, service: str, cancellable: Cancellable | None = None
     ) -> SocketConnection: ...
+    @overload
+    def connect_to_service_async(
+        self, domain: str, service: str, cancellable: Cancellable | None = None
+    ) -> _gi.Async[SocketConnection]: ...
+    @overload
+    def connect_to_service_async(
+        self,
+        domain: str,
+        service: str,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketClient, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def connect_to_service_async(
         self,
         domain: str,
         service: str,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketClient] | None,
     ) -> None: ...
     def connect_to_service_finish(self, result: AsyncResult) -> SocketConnection: ...
     def connect_to_uri(
         self, uri: str, default_port: int, cancellable: Cancellable | None = None
     ) -> SocketConnection: ...
+    @overload
+    def connect_to_uri_async(
+        self, uri: str, default_port: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[SocketConnection]: ...
+    @overload
+    def connect_to_uri_async(
+        self,
+        uri: str,
+        default_port: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketClient, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def connect_to_uri_async(
         self,
         uri: str,
         default_port: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketClient] | None,
     ) -> None: ...
     def connect_to_uri_finish(self, result: AsyncResult) -> SocketConnection: ...
     def do_event(
@@ -10811,13 +12428,25 @@ class SocketConnection(IOStream):
     def connect(
         self, address: SocketAddress, cancellable: Cancellable | None = None
     ) -> bool: ...
+    @overload
+    def connect_async(
+        self, address: SocketAddress, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def connect_async(
+        self,
+        address: SocketAddress,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def connect_async(
         self,
         address: SocketAddress,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketConnection] | None,
     ) -> None: ...
     def connect_finish(self, result: AsyncResult) -> bool: ...
     @staticmethod
@@ -10936,12 +12565,23 @@ class SocketListener(GObject.Object):
     def accept(
         self, cancellable: Cancellable | None = None
     ) -> tuple[SocketConnection, GObject.Object | None]: ...
+    @overload
+    def accept_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[SocketConnection, GObject.Object | None]]: ...
+    @overload
+    def accept_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketListener, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def accept_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketListener] | None,
     ) -> None: ...
     def accept_finish(
         self, result: AsyncResult
@@ -10949,12 +12589,23 @@ class SocketListener(GObject.Object):
     def accept_socket(
         self, cancellable: Cancellable | None = None
     ) -> tuple[Socket, GObject.Object | None]: ...
+    @overload
+    def accept_socket_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[Socket, GObject.Object | None]]: ...
+    @overload
+    def accept_socket_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[SocketListener, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def accept_socket_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[SocketListener] | None,
     ) -> None: ...
     def accept_socket_finish(
         self, result: AsyncResult
@@ -11136,13 +12787,27 @@ class Subprocess(GObject.Object, Initable):
         stdin_buf: GLib.Bytes | None = None,
         cancellable: Cancellable | None = None,
     ) -> tuple[bool, GLib.Bytes | None, GLib.Bytes | None]: ...
+    @overload
     def communicate_async(
         self,
         stdin_buf: GLib.Bytes | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, GLib.Bytes | None, GLib.Bytes | None]]: ...
+    @overload
+    def communicate_async(
+        self,
+        stdin_buf: GLib.Bytes | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Subprocess, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def communicate_async(
+        self,
+        stdin_buf: GLib.Bytes | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Subprocess] | None,
     ) -> None: ...
     def communicate_finish(
         self, result: AsyncResult
@@ -11150,13 +12815,25 @@ class Subprocess(GObject.Object, Initable):
     def communicate_utf8(
         self, stdin_buf: str | None = None, cancellable: Cancellable | None = None
     ) -> tuple[bool, str | None, str | None]: ...
+    @overload
+    def communicate_utf8_async(
+        self, stdin_buf: str | None = None, cancellable: Cancellable | None = None
+    ) -> _gi.Async[tuple[bool, str | None, str | None]]: ...
+    @overload
+    def communicate_utf8_async(
+        self,
+        stdin_buf: str | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Subprocess, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def communicate_utf8_async(
         self,
         stdin_buf: str | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Subprocess] | None,
     ) -> None: ...
     def communicate_utf8_finish(
         self, result: AsyncResult
@@ -11178,20 +12855,40 @@ class Subprocess(GObject.Object, Initable):
     ) -> Subprocess: ...
     def send_signal(self, signal_num: int) -> None: ...
     def wait(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def wait_async(self, cancellable: Cancellable | None = None) -> _gi.Async[bool]: ...
+    @overload
+    def wait_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Subprocess, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def wait_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Subprocess] | None,
     ) -> None: ...
     def wait_check(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def wait_check_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def wait_check_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Subprocess, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def wait_check_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Subprocess] | None,
     ) -> None: ...
     def wait_check_finish(self, result: AsyncResult) -> bool: ...
     def wait_finish(self, result: AsyncResult) -> bool: ...
@@ -11981,13 +13678,25 @@ class TlsConnection(IOStream):
     def get_require_close_notify(self) -> bool: ...
     def get_use_system_certdb(self) -> bool: ...
     def handshake(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def handshake_async(
+        self, io_priority: int, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def handshake_async(
+        self,
+        io_priority: int,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def handshake_async(
         self,
         io_priority: int,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[TlsConnection] | None,
     ) -> None: ...
     def handshake_finish(self, result: AsyncResult) -> bool: ...
     def set_advertised_protocols(
@@ -12156,15 +13865,33 @@ class TlsDatabase(GObject.Object):
         flags: _TlsDatabaseLookupFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> TlsCertificate | None: ...
+    @overload
     def lookup_certificate_for_handle_async(
         self,
         handle: str,
         interaction: TlsInteraction | None,
         flags: _TlsDatabaseLookupFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[TlsCertificate]: ...
+    @overload
+    def lookup_certificate_for_handle_async(
+        self,
+        handle: str,
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseLookupFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsDatabase, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def lookup_certificate_for_handle_async(
+        self,
+        handle: str,
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseLookupFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[TlsDatabase] | None,
     ) -> None: ...
     def lookup_certificate_for_handle_finish(
         self, result: AsyncResult
@@ -12176,15 +13903,33 @@ class TlsDatabase(GObject.Object):
         flags: _TlsDatabaseLookupFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> TlsCertificate: ...
+    @overload
     def lookup_certificate_issuer_async(
         self,
         certificate: TlsCertificate,
         interaction: TlsInteraction | None,
         flags: _TlsDatabaseLookupFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[TlsCertificate]: ...
+    @overload
+    def lookup_certificate_issuer_async(
+        self,
+        certificate: TlsCertificate,
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseLookupFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsDatabase, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def lookup_certificate_issuer_async(
+        self,
+        certificate: TlsCertificate,
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseLookupFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[TlsDatabase] | None,
     ) -> None: ...
     def lookup_certificate_issuer_finish(
         self, result: AsyncResult
@@ -12196,15 +13941,33 @@ class TlsDatabase(GObject.Object):
         flags: _TlsDatabaseLookupFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> list[TlsCertificate]: ...
+    @overload
     def lookup_certificates_issued_by_async(
         self,
         issuer_raw_dn: Sequence[int],
         interaction: TlsInteraction | None,
         flags: _TlsDatabaseLookupFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[list[TlsCertificate]]: ...
+    @overload
+    def lookup_certificates_issued_by_async(
+        self,
+        issuer_raw_dn: Sequence[int],
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseLookupFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsDatabase, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def lookup_certificates_issued_by_async(
+        self,
+        issuer_raw_dn: Sequence[int],
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseLookupFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[TlsDatabase] | None,
     ) -> None: ...
     def lookup_certificates_issued_by_finish(
         self, result: AsyncResult
@@ -12218,6 +13981,7 @@ class TlsDatabase(GObject.Object):
         flags: _TlsDatabaseVerifyFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> TlsCertificateFlags: ...
+    @overload
     def verify_chain_async(
         self,
         chain: TlsCertificate,
@@ -12226,9 +13990,30 @@ class TlsDatabase(GObject.Object):
         interaction: TlsInteraction | None,
         flags: _TlsDatabaseVerifyFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[TlsCertificateFlags]: ...
+    @overload
+    def verify_chain_async(
+        self,
+        chain: TlsCertificate,
+        purpose: str,
+        identity: SocketConnectable | None,
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseVerifyFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsDatabase, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def verify_chain_async(
+        self,
+        chain: TlsCertificate,
+        purpose: str,
+        identity: SocketConnectable | None,
+        interaction: TlsInteraction | None,
+        flags: _TlsDatabaseVerifyFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[TlsDatabase] | None,
     ) -> None: ...
     def verify_chain_finish(self, result: AsyncResult) -> TlsCertificateFlags: ...
 
@@ -12426,13 +14211,25 @@ class TlsInteraction(GObject.Object):
     def ask_password(
         self, password: TlsPassword, cancellable: Cancellable | None = None
     ) -> TlsInteractionResult: ...
+    @overload
+    def ask_password_async(
+        self, password: TlsPassword, cancellable: Cancellable | None = None
+    ) -> _gi.Async[TlsInteractionResult]: ...
+    @overload
+    def ask_password_async(
+        self,
+        password: TlsPassword,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsInteraction, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def ask_password_async(
         self,
         password: TlsPassword,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[TlsInteraction] | None,
     ) -> None: ...
     def ask_password_finish(self, result: AsyncResult) -> TlsInteractionResult: ...
     def do_ask_password(
@@ -12480,14 +14277,30 @@ class TlsInteraction(GObject.Object):
         flags: _TlsCertificateRequestFlagsValueType,
         cancellable: Cancellable | None = None,
     ) -> TlsInteractionResult: ...
+    @overload
     def request_certificate_async(
         self,
         connection: TlsConnection,
         flags: _TlsCertificateRequestFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[TlsInteractionResult]: ...
+    @overload
+    def request_certificate_async(
+        self,
+        connection: TlsConnection,
+        flags: _TlsCertificateRequestFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[TlsInteraction, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def request_certificate_async(
+        self,
+        connection: TlsConnection,
+        flags: _TlsCertificateRequestFlagsValueType,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[TlsInteraction] | None,
     ) -> None: ...
     def request_certificate_finish(
         self, result: AsyncResult
@@ -12700,22 +14513,44 @@ class UnixConnection(SocketConnection):
     def receive_credentials(
         self, cancellable: Cancellable | None = None
     ) -> Credentials: ...
+    @overload
+    def receive_credentials_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[Credentials]: ...
+    @overload
+    def receive_credentials_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[UnixConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def receive_credentials_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[UnixConnection] | None,
     ) -> None: ...
     def receive_credentials_finish(self, result: AsyncResult) -> Credentials: ...
     def receive_fd(self, cancellable: Cancellable | None = None) -> int: ...
     def send_credentials(self, cancellable: Cancellable | None = None) -> bool: ...
+    @overload
+    def send_credentials_async(
+        self, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def send_credentials_async(
+        self,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[UnixConnection, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def send_credentials_async(
         self,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[UnixConnection] | None,
     ) -> None: ...
     def send_credentials_finish(self, result: AsyncResult) -> bool: ...
     def send_fd(self, fd: int, cancellable: Cancellable | None = None) -> bool: ...
@@ -13046,23 +14881,51 @@ class Volume(GObject.GInterface, Protocol):
     """
     def can_eject(self) -> bool: ...
     def can_mount(self) -> bool: ...
+    @overload
+    def eject(
+        self, flags: _MountUnmountFlagsValueType, cancellable: Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Volume, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def eject(
         self,
         flags: _MountUnmountFlagsValueType,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: AsyncReadyCallback[Volume] | None,
     ) -> None: ...
     def eject_finish(self, result: AsyncResult) -> bool: ...
+    @overload
     def eject_with_operation(
         self,
         flags: _MountUnmountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def eject_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Volume, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def eject_with_operation(
+        self,
+        flags: _MountUnmountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Volume] | None,
     ) -> None: ...
     def eject_with_operation_finish(self, result: AsyncResult) -> bool: ...
     def enumerate_identifiers(self) -> list[str]: ...
@@ -13075,14 +14938,30 @@ class Volume(GObject.GInterface, Protocol):
     def get_sort_key(self) -> str | None: ...
     def get_symbolic_icon(self) -> Icon: ...
     def get_uuid(self) -> str | None: ...
+    @overload
     def mount(
         self,
         flags: _MountMountFlagsValueType,
         mount_operation: MountOperation | None = None,
         cancellable: Cancellable | None = None,
-        callback: Callable[[GObject.Object | None, AsyncResult, Unpack[_DataTs]], None]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def mount(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None,
+        cancellable: Cancellable | None,
+        callback: AsyncReadyCallback[Volume, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def mount(
+        self,
+        flags: _MountMountFlagsValueType,
+        mount_operation: MountOperation | None = None,
+        cancellable: Cancellable | None = None,
+        *,
+        callback: AsyncReadyCallback[Volume] | None,
     ) -> None: ...
     def mount_finish(self, result: AsyncResult) -> bool: ...
     def should_automount(self) -> bool: ...

--- a/src/gi-stubs/repository/Gly.pyi
+++ b/src/gi-stubs/repository/Gly.pyi
@@ -1,10 +1,9 @@
 from typing import Literal
+from typing import overload
 from typing import type_check_only
 from typing import TypeAlias
 from typing_extensions import TypeVarTuple
 from typing_extensions import Unpack
-
-from collections.abc import Callable
 
 from gi import _gi
 from gi.repository import Gio
@@ -85,14 +84,23 @@ class Creator(GObject.Object):
     ) -> NewFrame: ...
     def add_metadata_key_value(self, key: str, value: str) -> bool: ...
     def create(self) -> EncodedImage | None: ...
+    @overload
+    def create_async(
+        self, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[EncodedImage]: ...
+    @overload
+    def create_async(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Creator, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def create_async(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[Creator] | None,
     ) -> None: ...
     def create_finish(self, result: Gio.AsyncResult) -> EncodedImage: ...
     @classmethod
@@ -246,28 +254,47 @@ class Image(GObject.Object):
     def get_metadata_keys(self) -> list[str]: ...
     def get_mime_type(self) -> str: ...
     def get_specific_frame(self, frame_request: FrameRequest) -> Frame: ...
+    @overload
+    def get_specific_frame_async(
+        self, frame_request: FrameRequest, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Frame]: ...
+    @overload
+    def get_specific_frame_async(
+        self,
+        frame_request: FrameRequest,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Image, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def get_specific_frame_async(
         self,
         frame_request: FrameRequest,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[Image] | None,
     ) -> None: ...
     def get_specific_frame_finish(self, result: Gio.AsyncResult) -> Frame: ...
     def get_transformation_orientation(self) -> int: ...
     def get_width(self) -> int: ...
     def next_frame(self) -> Frame: ...
+    @overload
+    def next_frame_async(
+        self, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Frame]: ...
+    @overload
+    def next_frame_async(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Image, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def next_frame_async(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[Image] | None,
     ) -> None: ...
     def next_frame_finish(self, result: Gio.AsyncResult) -> Frame: ...
 
@@ -343,26 +370,45 @@ class Loader(GObject.Object):
     ) -> None: ...
     @staticmethod
     def get_mime_types() -> list[str]: ...
+    @overload
     @staticmethod
     def get_mime_types_async(
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[list[str]]: ...
+    @overload
+    @staticmethod
+    def get_mime_types_async(
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    @staticmethod
+    def get_mime_types_async(
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[None] | None,
     ) -> None: ...
     @staticmethod
     def get_mime_types_finish(result: Gio.AsyncResult) -> list[str]: ...
     def load(self) -> Image: ...
+    @overload
+    def load_async(
+        self, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Image]: ...
+    @overload
+    def load_async(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Loader, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def load_async(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[Loader] | None,
     ) -> None: ...
     def load_finish(self, result: Gio.AsyncResult) -> Image: ...
     @classmethod

--- a/src/gi-stubs/repository/_Gdk4.pyi
+++ b/src/gi-stubs/repository/_Gdk4.pyi
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Final
 from typing import Literal
+from typing import overload
 from typing import Protocol
 from typing import type_check_only
 from typing import TypeAlias
@@ -2510,15 +2511,33 @@ def color_state_get_rec2100_linear() -> ColorState: ...
 def color_state_get_rec2100_pq() -> ColorState: ...
 def color_state_get_srgb() -> ColorState: ...
 def color_state_get_srgb_linear() -> ColorState: ...
+@overload
 def content_deserialize_async(
     stream: Gio.InputStream,
     mime_type: str,
     type: type[Any],
     io_priority: int,
     cancellable: Gio.Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
+) -> _gi.Async[tuple[bool, Any]]: ...
+@overload
+def content_deserialize_async(
+    stream: Gio.InputStream,
+    mime_type: str,
+    type: type[Any],
+    io_priority: int,
+    cancellable: Gio.Cancellable | None,
+    callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
     *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
+def content_deserialize_async(
+    stream: Gio.InputStream,
+    mime_type: str,
+    type: type[Any],
+    io_priority: int,
+    cancellable: Gio.Cancellable | None = None,
+    *,
+    callback: Gio.AsyncReadyCallback[None] | None,
 ) -> None: ...
 def content_deserialize_finish(result: Gio.AsyncResult) -> tuple[bool, Any]: ...
 def content_formats_parse(string: str) -> ContentFormats | None: ...
@@ -2534,15 +2553,33 @@ def content_register_serializer(
     serialize: Callable[[ContentSerializer], None],
     *data: Unpack[_DataTs],
 ) -> None: ...
+@overload
 def content_serialize_async(
     stream: Gio.OutputStream,
     mime_type: str,
     value: Any,
     io_priority: int,
     cancellable: Gio.Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
+) -> _gi.Async[bool]: ...
+@overload
+def content_serialize_async(
+    stream: Gio.OutputStream,
+    mime_type: str,
+    value: Any,
+    io_priority: int,
+    cancellable: Gio.Cancellable | None,
+    callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
     *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
+def content_serialize_async(
+    stream: Gio.OutputStream,
+    mime_type: str,
+    value: Any,
+    io_priority: int,
+    cancellable: Gio.Cancellable | None = None,
+    *,
+    callback: Gio.AsyncReadyCallback[None] | None,
 ) -> None: ...
 def content_serialize_finish(result: Gio.AsyncResult) -> bool: ...
 def dmabuf_error_quark() -> int: ...
@@ -2731,65 +2768,119 @@ class Clipboard(GObject.Object):
     def get_display(self) -> Display: ...
     def get_formats(self) -> ContentFormats: ...
     def is_local(self) -> bool: ...
+    @overload
     def read_async(
         self,
         mime_types: Sequence[str],
         io_priority: int,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[tuple[Gio.InputStream | None, str]]: ...
+    @overload
+    def read_async(
+        self,
+        mime_types: Sequence[str],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Clipboard, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def read_async(
+        self,
+        mime_types: Sequence[str],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[Clipboard] | None,
     ) -> None: ...
     def read_finish(
         self, result: Gio.AsyncResult
     ) -> tuple[Gio.InputStream | None, str]: ...
+    @overload
+    def read_text_async(
+        self, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[str | None]: ...
+    @overload
+    def read_text_async(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Clipboard, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def read_text_async(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[Clipboard] | None,
+    ) -> None: ...
+    def read_text_finish(self, result: Gio.AsyncResult) -> str | None: ...
+    @overload
+    def read_texture_async(
+        self, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Texture | None]: ...
+    @overload
+    def read_texture_async(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Clipboard, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
-    # override
-    def read_text_finish(self, result: Gio.AsyncResult) -> str | None: ...
+    @overload
     def read_texture_async(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[Clipboard] | None,
     ) -> None: ...
-    # override
     def read_texture_finish(self, result: Gio.AsyncResult) -> Texture | None: ...
+    @overload
     def read_value_async(
         self,
         type: type[Any],
         io_priority: int,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[Any]: ...
+    @overload
+    def read_value_async(
+        self,
+        type: type[Any],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Clipboard, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def read_value_async(
+        self,
+        type: type[Any],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[Clipboard] | None,
     ) -> None: ...
     def read_value_finish(self, result: Gio.AsyncResult) -> Any: ...
     def set(self, value: Any) -> None: ...
     def set_content(self, provider: ContentProvider | None = None) -> bool: ...
+    @overload
+    def store_async(
+        self, io_priority: int, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def store_async(
+        self,
+        io_priority: int,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Clipboard, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def store_async(
         self,
         io_priority: int,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[Clipboard] | None,
     ) -> None: ...
     def store_finish(self, result: Gio.AsyncResult) -> bool: ...
 
@@ -2958,17 +3049,33 @@ class ContentProvider(GObject.Object):
     ) -> ContentProvider: ...
     def ref_formats(self) -> ContentFormats: ...
     def ref_storable_formats(self) -> ContentFormats: ...
+    @overload
     def write_mime_type_async(
         self,
         mime_type: str,
         stream: Gio.OutputStream,
         io_priority: int,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def write_mime_type_async(
+        self,
+        mime_type: str,
+        stream: Gio.OutputStream,
+        io_priority: int,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[ContentProvider, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def write_mime_type_async(
+        self,
+        mime_type: str,
+        stream: Gio.OutputStream,
+        io_priority: int,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[ContentProvider] | None,
     ) -> None: ...
     def write_mime_type_finish(self, result: Gio.AsyncResult) -> bool: ...
 
@@ -3753,30 +3860,58 @@ class Drop(GObject.Object):
     def get_drag(self) -> Drag | None: ...
     def get_formats(self) -> ContentFormats: ...
     def get_surface(self) -> Surface: ...
+    @overload
     def read_async(
         self,
         mime_types: Sequence[str],
         io_priority: int,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[tuple[Gio.InputStream | None, str]]: ...
+    @overload
+    def read_async(
+        self,
+        mime_types: Sequence[str],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Drop, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def read_async(
+        self,
+        mime_types: Sequence[str],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[Drop] | None,
     ) -> None: ...
     def read_finish(
         self, result: Gio.AsyncResult
     ) -> tuple[Gio.InputStream | None, str]: ...
+    @overload
     def read_value_async(
         self,
         type: type[Any],
         io_priority: int,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[Any]: ...
+    @overload
+    def read_value_async(
+        self,
+        type: type[Any],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[Drop, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def read_value_async(
+        self,
+        type: type[Any],
+        io_priority: int,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[Drop] | None,
     ) -> None: ...
     def read_value_finish(self, result: Gio.AsyncResult) -> Any: ...
     def status(

--- a/src/gi-stubs/repository/_Gtk3.pyi
+++ b/src/gi-stubs/repository/_Gtk3.pyi
@@ -26416,14 +26416,23 @@ class IconInfo(GObject.Object):
     def get_filename(self) -> str | None: ...
     def is_symbolic(self) -> bool: ...
     def load_icon(self) -> GdkPixbuf.Pixbuf: ...
+    @overload
+    def load_icon_async(
+        self, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[GdkPixbuf.Pixbuf]: ...
+    @overload
+    def load_icon_async(
+        self,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[IconInfo, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def load_icon_async(
         self,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[IconInfo] | None,
     ) -> None: ...
     def load_icon_finish(self, res: Gio.AsyncResult) -> GdkPixbuf.Pixbuf: ...
     # override
@@ -26437,6 +26446,7 @@ class IconInfo(GObject.Object):
         warning_color: _Gdk3.RGBA | None = None,
         error_color: _Gdk3.RGBA | None = None,
     ) -> tuple[GdkPixbuf.Pixbuf, bool]: ...
+    @overload
     def load_symbolic_async(
         self,
         fg: _Gdk3.RGBA,
@@ -26444,11 +26454,28 @@ class IconInfo(GObject.Object):
         warning_color: _Gdk3.RGBA | None = None,
         error_color: _Gdk3.RGBA | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[tuple[GdkPixbuf.Pixbuf, bool]]: ...
+    @overload
+    def load_symbolic_async(
+        self,
+        fg: _Gdk3.RGBA,
+        success_color: _Gdk3.RGBA | None,
+        warning_color: _Gdk3.RGBA | None,
+        error_color: _Gdk3.RGBA | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[IconInfo, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def load_symbolic_async(
+        self,
+        fg: _Gdk3.RGBA,
+        success_color: _Gdk3.RGBA | None = None,
+        warning_color: _Gdk3.RGBA | None = None,
+        error_color: _Gdk3.RGBA | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[IconInfo] | None,
     ) -> None: ...
     def load_symbolic_finish(
         self, res: Gio.AsyncResult
@@ -26456,15 +26483,25 @@ class IconInfo(GObject.Object):
     def load_symbolic_for_context(
         self, context: StyleContext
     ) -> tuple[GdkPixbuf.Pixbuf, bool]: ...
+    @overload
+    def load_symbolic_for_context_async(
+        self, context: StyleContext, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[tuple[GdkPixbuf.Pixbuf, bool]]: ...
+    @overload
+    def load_symbolic_for_context_async(
+        self,
+        context: StyleContext,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[IconInfo, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def load_symbolic_for_context_async(
         self,
         context: StyleContext,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[IconInfo] | None,
     ) -> None: ...
     def load_symbolic_for_context_finish(
         self, res: Gio.AsyncResult

--- a/src/gi-stubs/repository/_Gtk4.pyi
+++ b/src/gi-stubs/repository/_Gtk4.pyi
@@ -334,14 +334,30 @@ def render_option(
 def rgb_to_hsv(r: float, g: float, b: float) -> tuple[float, float, float]: ...
 def set_debug_flags(flags: _DebugFlagsValueType) -> None: ...
 def show_uri(parent: Window | None, uri: str, timestamp: int) -> None: ...
+@overload
 def show_uri_full(
     parent: Window | None,
     uri: str,
     timestamp: int,
     cancellable: Gio.Cancellable | None = None,
-    callback: Callable[[GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None]
-    | None = None,
+) -> _gi.Async[bool]: ...
+@overload
+def show_uri_full(
+    parent: Window | None,
+    uri: str,
+    timestamp: int,
+    cancellable: Gio.Cancellable | None,
+    callback: Gio.AsyncReadyCallback[None, Unpack[_DataTs]] | None,
     *user_data: Unpack[_DataTs],
+) -> None: ...
+@overload
+def show_uri_full(
+    parent: Window | None,
+    uri: str,
+    timestamp: int,
+    cancellable: Gio.Cancellable | None = None,
+    *,
+    callback: Gio.AsyncReadyCallback[None] | None,
 ) -> None: ...
 def show_uri_full_finish(parent: Window, result: Gio.AsyncResult) -> bool: ...
 def test_accessible_assertion_message_role(
@@ -1208,15 +1224,25 @@ class AlertDialog(GObject.Object):
         message: str = ...,
         modal: bool = ...,
     ) -> None: ...
+    @overload
+    def choose(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[int]: ...
+    @overload
+    def choose(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[AlertDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def choose(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[AlertDialog] | None,
     ) -> None: ...
     def choose_finish(self, result: Gio.AsyncResult) -> int: ...
     def get_buttons(self) -> list[str]: ...
@@ -6851,16 +6877,30 @@ class ColorDialog(GObject.Object):
     def __init__(
         self, *, modal: bool = ..., title: str = ..., with_alpha: bool = ...
     ) -> None: ...
+    @overload
     def choose_rgba(
         self,
         parent: Window | None = None,
         initial_color: _Gdk4.RGBA | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[_Gdk4.RGBA]: ...
+    @overload
+    def choose_rgba(
+        self,
+        parent: Window | None,
+        initial_color: _Gdk4.RGBA | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[ColorDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def choose_rgba(
+        self,
+        parent: Window | None = None,
+        initial_color: _Gdk4.RGBA | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[ColorDialog] | None,
     ) -> None: ...
     def choose_rgba_finish(self, result: Gio.AsyncResult) -> _Gdk4.RGBA: ...
     def get_modal(self) -> bool: ...
@@ -11449,98 +11489,178 @@ class FileDialog(GObject.Object):
     def get_title(self) -> str: ...
     @classmethod
     def new(cls) -> FileDialog: ...
+    @overload
+    def open(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Gio.File]: ...
+    @overload
+    def open(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def open(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def open_finish(self, result: Gio.AsyncResult) -> Gio.File: ...
+    @overload
+    def open_multiple(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Gio.ListModel]: ...
+    @overload
+    def open_multiple(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def open_multiple(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def open_multiple_finish(self, result: Gio.AsyncResult) -> Gio.ListModel: ...
+    @overload
+    def open_multiple_text_files(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[tuple[Gio.ListModel, str]]: ...
+    @overload
+    def open_multiple_text_files(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def open_multiple_text_files(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def open_multiple_text_files_finish(
         self, result: Gio.AsyncResult
     ) -> tuple[Gio.ListModel, str]: ...
+    @overload
+    def open_text_file(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[tuple[Gio.File, str]]: ...
+    @overload
+    def open_text_file(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def open_text_file(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def open_text_file_finish(
         self, result: Gio.AsyncResult
     ) -> tuple[Gio.File, str]: ...
+    @overload
+    def save(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Gio.File]: ...
+    @overload
+    def save(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def save(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def save_finish(self, result: Gio.AsyncResult) -> Gio.File: ...
+    @overload
+    def save_text_file(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[tuple[Gio.File, str, str]]: ...
+    @overload
+    def save_text_file(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def save_text_file(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def save_text_file_finish(
         self, result: Gio.AsyncResult
     ) -> tuple[Gio.File, str, str]: ...
+    @overload
+    def select_folder(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Gio.File]: ...
+    @overload
+    def select_folder(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def select_folder(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def select_folder_finish(self, result: Gio.AsyncResult) -> Gio.File: ...
+    @overload
+    def select_multiple_folders(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[Gio.ListModel]: ...
+    @overload
+    def select_multiple_folders(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def select_multiple_folders(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileDialog] | None,
     ) -> None: ...
     def select_multiple_folders_finish(
         self, result: Gio.AsyncResult
@@ -11654,28 +11774,48 @@ class FileLauncher(GObject.Object):
     def get_always_ask(self) -> bool: ...
     def get_file(self) -> Gio.File | None: ...
     def get_writable(self) -> bool: ...
+    @overload
+    def launch(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def launch(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileLauncher, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def launch(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileLauncher] | None,
     ) -> None: ...
     def launch_finish(self, result: Gio.AsyncResult) -> bool: ...
     @classmethod
     def new(cls, file: Gio.File | None = None) -> FileLauncher: ...
+    @overload
+    def open_containing_folder(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def open_containing_folder(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FileLauncher, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def open_containing_folder(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[FileLauncher] | None,
     ) -> None: ...
     def open_containing_folder_finish(self, result: Gio.AsyncResult) -> bool: ...
     def set_always_ask(self, always_ask: bool) -> None: ...
@@ -13060,51 +13200,107 @@ class FontDialog(GObject.Object):
         modal: bool = ...,
         title: str = ...,
     ) -> None: ...
+    @overload
     def choose_face(
         self,
         parent: Window | None = None,
         initial_value: Pango.FontFace | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[Pango.FontFace]: ...
+    @overload
+    def choose_face(
+        self,
+        parent: Window | None,
+        initial_value: Pango.FontFace | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FontDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def choose_face(
+        self,
+        parent: Window | None = None,
+        initial_value: Pango.FontFace | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[FontDialog] | None,
+    ) -> None: ...
     def choose_face_finish(self, result: Gio.AsyncResult) -> Pango.FontFace: ...
+    @overload
     def choose_family(
         self,
         parent: Window | None = None,
         initial_value: Pango.FontFamily | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[Pango.FontFamily]: ...
+    @overload
+    def choose_family(
+        self,
+        parent: Window | None,
+        initial_value: Pango.FontFamily | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FontDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def choose_family(
+        self,
+        parent: Window | None = None,
+        initial_value: Pango.FontFamily | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[FontDialog] | None,
+    ) -> None: ...
     def choose_family_finish(self, result: Gio.AsyncResult) -> Pango.FontFamily: ...
+    @overload
     def choose_font(
         self,
         parent: Window | None = None,
         initial_value: Pango.FontDescription | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[Pango.FontDescription]: ...
+    @overload
+    def choose_font(
+        self,
+        parent: Window | None,
+        initial_value: Pango.FontDescription | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FontDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def choose_font(
+        self,
+        parent: Window | None = None,
+        initial_value: Pango.FontDescription | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[FontDialog] | None,
+    ) -> None: ...
+    @overload
     def choose_font_and_features(
         self,
         parent: Window | None = None,
         initial_value: Pango.FontDescription | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[tuple[bool, Pango.FontDescription, str, Pango.Language]]: ...
+    @overload
+    def choose_font_and_features(
+        self,
+        parent: Window | None,
+        initial_value: Pango.FontDescription | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[FontDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def choose_font_and_features(
+        self,
+        parent: Window | None = None,
+        initial_value: Pango.FontDescription | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[FontDialog] | None,
     ) -> None: ...
     def choose_font_and_features_finish(
         self, result: Gio.AsyncResult
@@ -21441,28 +21637,58 @@ class PrintDialog(GObject.Object):
     def get_title(self) -> str: ...
     @classmethod
     def new(cls) -> PrintDialog: ...
+    @overload
     def print_(
         self,
         parent: Window | None = None,
         setup: PrintSetup | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[Gio.OutputStream]: ...
+    @overload
+    def print_(
+        self,
+        parent: Window | None,
+        setup: PrintSetup | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[PrintDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
     ) -> None: ...
+    @overload
+    def print_(
+        self,
+        parent: Window | None = None,
+        setup: PrintSetup | None = None,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[PrintDialog] | None,
+    ) -> None: ...
+    @overload
     def print_file(
         self,
         parent: Window | None,
         setup: PrintSetup | None,
         file: Gio.File,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def print_file(
+        self,
+        parent: Window | None,
+        setup: PrintSetup | None,
+        file: Gio.File,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[PrintDialog, Unpack[_DataTs]] | None,
         *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
+    def print_file(
+        self,
+        parent: Window | None,
+        setup: PrintSetup | None,
+        file: Gio.File,
+        cancellable: Gio.Cancellable | None = None,
+        *,
+        callback: Gio.AsyncReadyCallback[PrintDialog] | None,
     ) -> None: ...
     def print_file_finish(self, result: Gio.AsyncResult) -> bool: ...
     def print_finish(self, result: Gio.AsyncResult) -> Gio.OutputStream: ...
@@ -21471,15 +21697,25 @@ class PrintDialog(GObject.Object):
     def set_page_setup(self, page_setup: PageSetup) -> None: ...
     def set_print_settings(self, print_settings: PrintSettings) -> None: ...
     def set_title(self, title: str) -> None: ...
+    @overload
+    def setup(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[PrintSetup]: ...
+    @overload
+    def setup(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[PrintDialog, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def setup(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[PrintDialog] | None,
     ) -> None: ...
     def setup_finish(self, result: Gio.AsyncResult) -> PrintSetup: ...
 
@@ -30771,7 +31007,7 @@ class TreeViewColumn(GObject.InitiallyUnowned, Buildable, CellLayout):
     def set_alignment(self, xalign: float) -> None: ...
     # override
     def set_attributes(
-        self, cell_renderer: CellRenderer, **attributes: Any
+        self, cell_renderer: CellRenderer, **attributes: object
     ) -> None: ...
     # override
     @overload
@@ -30832,15 +31068,25 @@ class UriLauncher(GObject.Object):
     def __init__(self, *, uri: str | None = ...) -> None: ...
     def can_launch(self, parent: Window | None = None) -> bool: ...
     def get_uri(self) -> str | None: ...
+    @overload
+    def launch(
+        self, parent: Window | None = None, cancellable: Gio.Cancellable | None = None
+    ) -> _gi.Async[bool]: ...
+    @overload
+    def launch(
+        self,
+        parent: Window | None,
+        cancellable: Gio.Cancellable | None,
+        callback: Gio.AsyncReadyCallback[UriLauncher, Unpack[_DataTs]] | None,
+        *user_data: Unpack[_DataTs],
+    ) -> None: ...
+    @overload
     def launch(
         self,
         parent: Window | None = None,
         cancellable: Gio.Cancellable | None = None,
-        callback: Callable[
-            [GObject.Object | None, Gio.AsyncResult, Unpack[_DataTs]], None
-        ]
-        | None = None,
-        *user_data: Unpack[_DataTs],
+        *,
+        callback: Gio.AsyncReadyCallback[UriLauncher] | None,
     ) -> None: ...
     def launch_finish(self, result: Gio.AsyncResult) -> bool: ...
     @classmethod

--- a/src/pygobject_stub_generator/arguments.py
+++ b/src/pygobject_stub_generator/arguments.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+from typing import cast
 from typing import Final
 from typing import TYPE_CHECKING
 from typing_extensions import Self
 
 from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import replace
 
 import gi._gi as GI
+
+from .utils import cache_slot
+from .utils import MISSING
+from .utils import MissingType
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -27,6 +34,30 @@ class VisibleArgument:
     is_varargs_slot: bool
     is_varargs_callback: bool
 
+    _callable_info: GI.CallableInfo | None = field(init=False, default=None, hash=False)
+    _callable_container: GI.BaseInfo | MissingType | None = field(
+        init=False, default=MISSING, hash=False
+    )
+
+    @property
+    @cache_slot
+    def callable_info(self) -> GI.CallableInfo:
+        return cast("GI.CallableInfo", self.info.get_container())
+
+    @property
+    def callable_flags(self) -> int:
+        info = self.callable_info
+
+        if isinstance(info, GI.FunctionInfo):
+            return info.get_flags()
+
+        return 0
+
+    @property
+    @cache_slot(default=MISSING)
+    def callable_container(self) -> GI.BaseInfo | None:
+        return self.callable_info.get_container()
+
 
 @dataclass(slots=True, frozen=True)
 class Arguments:
@@ -35,6 +66,9 @@ class Arguments:
     hidden: frozenset[int]
     closure_targets: frozenset[int]
     varargs_index: int | None
+    async_callback_index: int | None
+    async_cancellable_index: int | None
+    async_user_data_index: int | None
 
     @property
     def varargs_info(self) -> GI.ArgInfo | None:
@@ -65,6 +99,40 @@ class Arguments:
                 is_varargs_callback=closure_index == self.varargs_index,
             )
 
+    def as_async(self) -> Self | None:
+        if (
+            self.async_callback_index is None
+            or self.async_cancellable_index is None
+            or self.async_user_data_index is None
+        ):
+            return None
+
+        return replace(
+            self,
+            hidden=self.hidden
+            | {
+                self.async_callback_index,
+                self.async_user_data_index,
+            },
+            varargs_index=None,
+            closure_targets=self.closure_targets - {self.async_user_data_index},
+        )
+
+    def as_async_callback_kwargs(self) -> Self | None:
+        if (
+            self.async_callback_index is None
+            or self.async_cancellable_index is None
+            or self.async_user_data_index is None
+        ):
+            return None
+
+        return replace(
+            self,
+            hidden=self.hidden | {self.async_user_data_index},
+            varargs_index=None,
+            closure_targets=self.closure_targets - {self.async_user_data_index},
+        )
+
     @classmethod
     def for_callable(
         cls, info: GI.CallableInfo, /, *, allow_varargs: bool = True
@@ -74,6 +142,9 @@ class Arguments:
         hidden_indexes: set[int] = set()
         closure_indexes: set[int] = set()
         from_python_indexes: set[int] = set()
+        async_callback_index: int | None = None
+        async_cancellable_index: int | None = None
+        async_user_data_index: int | None = None
 
         if (
             return_array_length_index := info.get_return_type().get_array_length_index()
@@ -121,20 +192,37 @@ class Arguments:
                 ):
                     hidden_indexes.add(array_length_index)
 
-                # Hide destroy and closure args for callbacks
-                if (
-                    tag == GI.TypeTag.INTERFACE
-                    and isinstance(type_info.get_interface(), GI.CallbackInfo)
-                    and arg_index not in hidden_indexes
-                    and arg_index not in closure_indexes
-                ):
-                    if (
-                        closure_index := arg.get_closure_index()
-                    ) > -1 and is_from_python:
-                        closure_indexes.add(closure_index)
+                if tag == GI.TypeTag.INTERFACE:
+                    iface_info = type_info.get_interface()
 
-                    if (destroy_index := arg.get_destroy_index()) > -1:
-                        hidden_indexes.add(destroy_index)
+                    if isinstance(iface_info, GI.CallbackInfo):
+                        # Hide destroy and closure args for callbacks
+                        if (
+                            arg_index not in hidden_indexes
+                            and arg_index not in closure_indexes
+                        ):
+                            if (
+                                closure_index := arg.get_closure_index()
+                            ) > -1 and is_from_python:
+                                closure_indexes.add(closure_index)
+
+                            if (destroy_index := arg.get_destroy_index()) > -1:
+                                hidden_indexes.add(destroy_index)
+
+                        if arg.get_scope() == GI.ScopeType.ASYNC:
+                            async_callback_index = arg_index
+
+                            if (
+                                closure_index := arg.get_closure_index()
+                            ) > -1 and is_from_python:
+                                async_user_data_index = closure_index
+
+                    if (
+                        isinstance(iface_info, GI.ObjectInfo)
+                        and f"{iface_info.get_namespace()}.{iface_info.get_name()}"
+                        == "Gio.Cancellable"
+                    ):
+                        async_cancellable_index = arg_index
 
                 if is_from_python:
                     from_python_indexes.add(arg_index)
@@ -161,4 +249,7 @@ class Arguments:
             hidden=frozenset(hidden_indexes),
             closure_targets=frozenset(closure_indexes),
             varargs_index=varargs_index,
+            async_callback_index=async_callback_index,
+            async_cancellable_index=async_cancellable_index,
+            async_user_data_index=async_user_data_index,
         )

--- a/src/pygobject_stub_generator/class_info.py
+++ b/src/pygobject_stub_generator/class_info.py
@@ -21,6 +21,8 @@ import gi._gi as GI
 
 from .property_info import PropertyInfo
 from .utils import generate_full_name
+from .utils import MISSING
+from .utils import MissingType
 
 gi.require_version("GIRepository", "3.0")
 
@@ -36,7 +38,6 @@ else:
     from gi.repository import GIRepository
 
 PropertyInfoDict: TypeAlias = dict[str, PropertyInfo]
-_MISSING = object()
 
 
 def _find_attributes(obj: type[Any]) -> list[str]:
@@ -64,8 +65,8 @@ class ClassInfo:
     full_name: str = field(init=False)
 
     _bases: tuple[type[Any], ...] | None = field(init=False, default=None)
-    _gi_info: GI.RegisteredTypeInfo | None = field(
-        init=False, default=cast("Any", _MISSING)
+    _gi_info: GI.RegisteredTypeInfo | MissingType | None = field(
+        init=False, default=MISSING
     )
     _class_properties: PropertyInfoDict | None = field(init=False, default=None)
     _init_properties: PropertyInfoDict | None = field(init=False, default=None)
@@ -94,7 +95,7 @@ class ClassInfo:
 
     @property
     def gi_info(self) -> GI.RegisteredTypeInfo | None:
-        if self._gi_info is not _MISSING:
+        if self._gi_info is not MISSING:
             return self._gi_info
 
         self._bases, self._gi_info = self.__get_bases_and_gi_info()

--- a/src/pygobject_stub_generator/stub.py
+++ b/src/pygobject_stub_generator/stub.py
@@ -6,6 +6,7 @@ from typing import Final
 from typing import get_args
 from typing import get_origin
 from typing import Literal
+from typing import overload
 from typing import TYPE_CHECKING
 from typing import TypeAlias
 from typing_extensions import get_overloads
@@ -32,8 +33,12 @@ from .import_info import ImportInfo
 from .type_var_info import TypeVarInfo
 from .type_var_info import TypeVarTupleInfo
 from .utils import generate_full_name
+from .utils import get_finish_func
 from .utils import get_return_type
+from .utils import get_value
 from .utils import make_nullable
+from .utils import MISSING
+from .utils import MissingType
 
 gi.require_version("GIRepository", "3.0")
 
@@ -51,6 +56,9 @@ else:
     from gi.repository import GIRepository
 
 _Object: TypeAlias = ModuleType | type[Any]
+_FunctionMode: TypeAlias = Literal[
+    "sync", "awaitable", "async_callback", "async_callback_kwargs"
+]
 
 _identifier_re: Final = re.compile(r"^[A-Za-z_]\w*$")
 _typing_re: Final = re.compile(r"(?:typing\.)(?P<name>\w+)\b")
@@ -252,12 +260,24 @@ class Stub:
         self.__add_import(module, name, None if import_as == name else import_as)
         return import_as
 
+    @overload
+    def get_namespace_member(self, info: GI.BaseInfo, /) -> str: ...
+    @overload
+    def get_namespace_member(self, namespace: str, name: str, /) -> str: ...
+
     def get_namespace_member(
         self,
-        namespace: str,
-        name: str,
+        namespace: str | GI.BaseInfo,
+        name: str | None = None,
         /,
     ) -> str:
+        if isinstance(namespace, GI.BaseInfo):
+            name = f"{namespace.get_name()}"
+            namespace = namespace.get_namespace()
+
+        if name is None:
+            raise ValueError("Name must be provided when namespace is a string")
+
         if namespace == self.namespace:
             return name
 
@@ -312,8 +332,7 @@ class Stub:
 
     def get_typevar_tuple(self, name: str, /, *, default: str | None = None) -> str:
         if default is not None:
-            unpack_symbol = self.get_import("typing", "Unpack")
-            default = f"{unpack_symbol}[{default}]"
+            default = self.get_unpack(default)
 
         typevar_tuple = TypeVarTupleInfo(name, default)
 
@@ -339,6 +358,12 @@ class Stub:
 
     def get_literal(self, annotation: str, /) -> str:
         return f"{self.get_import('typing', 'Literal')}[{annotation}]"
+
+    def get_unpack(self, annotation: str, /) -> str:
+        return f"{self.get_import('typing', 'Unpack')}[{annotation}]"
+
+    def get_unpack_data_ts(self) -> str:
+        return self.get_unpack(self.get_callback_typevar_tuple())
 
     def get_type_alias(self, name: str, /) -> str:
         return f"{name}: {self.get_import('typing', 'TypeAlias')}"
@@ -433,9 +458,26 @@ class Stub:
         return name.replace("-", "_")
 
     def get_callable_arguments(
-        self, info: GI.CallableInfo, /, *, allow_varargs: bool = True
+        self,
+        info: GI.CallableInfo,
+        /,
+        *,
+        allow_varargs: bool = True,
+        mode: _FunctionMode = "sync",
     ) -> tuple[dict[str, str], list[str]]:
         arguments = Arguments.for_callable(info, allow_varargs=allow_varargs)
+
+        is_awaitable_eligible = (
+            isinstance(info, GI.FunctionInfo) and get_finish_func(info) is not None
+        )
+
+        if mode == "awaitable":
+            arguments = arguments.as_async()
+        elif mode == "async_callback_kwargs":
+            arguments = arguments.as_async_callback_kwargs()
+
+        if arguments is None:
+            raise ValueError("Callable is not eligible for async transformation")
 
         py_args: list[VisibleArgument] = []
         return_args: list[str] = []
@@ -448,6 +490,16 @@ class Stub:
                 if arg.required:
                     required_indexes.add(arg.c_index)
 
+                if (
+                    mode in {"async_callback", "async_callback_kwargs"}
+                    and arg.c_index == arguments.async_callback_index
+                ):
+                    py_args[-1] = replace(py_args[-1], required=True)
+
+                    # the kwargs variant doesn't require the callback
+                    if mode == "async_callback":
+                        required_indexes.add(arg.c_index)
+
             if arg.to_python:
                 return_args.append(
                     self.type_info_to_python(
@@ -459,22 +511,47 @@ class Stub:
         args: dict[str, str] = {}
 
         for py_arg in py_args:
-            arg_type = self.type_info_to_python(
-                py_arg.info.get_type_info(),
-                nullable=py_arg.nullable,
-                varargs_callback=py_arg.is_varargs_callback,
-                closure_argument=py_arg.is_closure_target,
+            if (
+                is_awaitable_eligible
+                and py_arg.c_index == arguments.async_callback_index
+            ):
+                arg_type = self.type_info_to_python(
+                    py_arg.info.get_type_info(),
+                    nullable=py_arg.nullable,
+                    async_callback_argument=py_arg,
+                )
+            else:
+                arg_type = self.type_info_to_python(
+                    py_arg.info.get_type_info(),
+                    nullable=py_arg.nullable,
+                    varargs_callback=py_arg.is_varargs_callback,
+                    closure_argument=py_arg.is_closure_target,
+                )
+
+            is_kw_only_callback = (
+                mode == "async_callback_kwargs"
+                and py_arg.c_index == arguments.async_callback_index
             )
 
-            if arguments.can_have_defaults and py_arg.c_index > last_required:
+            if (
+                arguments.can_have_defaults
+                and py_arg.c_index > last_required
+                and not is_kw_only_callback
+            ):
                 arg_type = f"{arg_type} = {'None' if py_arg.nullable else '...'}"
+
+            if (
+                mode == "async_callback_kwargs"
+                and py_arg.c_index == arguments.async_callback_index
+            ):
+                args["*"] = ""
 
             args[self.fix_argument_name(py_arg.info.get_name())] = arg_type
 
         if (varargs_info := arguments.varargs_info) is not None:
-            args[f"*{self.fix_argument_name(varargs_info.get_name())}"] = f"{
-                self.get_import('typing', 'Unpack')
-            }[{self.get_callback_typevar_tuple()}]"
+            args[f"*{self.fix_argument_name(varargs_info.get_name())}"] = (
+                self.get_unpack_data_ts()
+            )
 
         return_type = info.get_return_type()
         if not info.skip_return() and (
@@ -491,14 +568,28 @@ class Stub:
 
     def type_info_to_python(
         self,
-        info: GI.TypeInfo,
+        info: GI.TypeInfo | VisibleArgument,
         /,
         *,
         out: bool = False,
-        nullable: bool = False,
-        varargs_callback: bool = False,
-        closure_argument: bool = False,
+        nullable: bool | MissingType = MISSING,
+        varargs_callback: bool | MissingType = MISSING,
+        closure_argument: bool | MissingType = MISSING,
+        async_callback_argument: VisibleArgument | None = None,
     ) -> str:
+        py_arg: VisibleArgument | None = None
+        if isinstance(info, VisibleArgument):
+            py_arg = info
+            info = py_arg.info.get_type_info()
+
+        nullable = get_value(nullable, False if py_arg is None else py_arg.nullable)
+        varargs_callback = get_value(
+            varargs_callback, False if py_arg is None else py_arg.is_varargs_callback
+        )
+        closure_argument = get_value(
+            closure_argument, False if py_arg is None else py_arg.is_closure_target
+        )
+
         tag = info.get_tag()
 
         py_type: str | None = None
@@ -583,9 +674,7 @@ class Stub:
                     #         )
                     #         not in _EXCLUDED_VARARGS_CALLBACKS
                     #     ):
-                    #         py_type = f"{py_type}[{
-                    #             self.get_import('typing', 'Unpack')
-                    #         }[{self.get_callback_typevar_tuple()}]]"
+                    #         py_type = f"{py_type}[{self.get_unpack_data_ts()}]"
                     # else:
                     #     # Generate the `Callable[]` annotation for anonymous callbacks
                     #     (callback_args, callback_return_args) = (
@@ -600,14 +689,49 @@ class Stub:
                     #     }[[{
                     #         ', '.join(callback_args.values())
                     #     }], {callback_return_type}]"
-                    (callback_args, callback_return_args) = self.get_callable_arguments(
-                        interface_info, allow_varargs=varargs_callback
-                    )
-                    callback_return_type = get_return_type(callback_return_args)
 
-                    py_type = f"{self.get_import('collections.abc', 'Callable')}[[{
-                        ', '.join(callback_args.values())
-                    }], {callback_return_type}]"
+                    if (
+                        async_callback_argument is not None
+                        and f"{interface_info.get_namespace()}.{
+                            interface_info.get_name()
+                        }"
+                        == "Gio.AsyncReadyCallback"
+                    ):
+                        callback_symbol = self.get_namespace_member(
+                            "Gio", "AsyncReadyCallback"
+                        )
+                        class_info = async_callback_argument.callable_container
+                        source_type = (
+                            "None"
+                            if class_info is None
+                            or not (
+                                async_callback_argument.callable_flags
+                                & (
+                                    GI.FunctionInfoFlags.IS_METHOD
+                                    | GI.FunctionInfoFlags.IS_CONSTRUCTOR
+                                )
+                            )
+                            else self.get_namespace_member(class_info)
+                        )
+                        user_data_args = (
+                            f", {self.get_unpack_data_ts()}"
+                            if async_callback_argument.is_varargs_callback
+                            else ""
+                        )
+
+                        py_type = f"{callback_symbol}[{source_type}{user_data_args}]"
+                    else:
+                        (callback_args, callback_return_args) = (
+                            self.get_callable_arguments(
+                                interface_info,
+                                allow_varargs=varargs_callback,
+                            )
+                        )
+                        callback_return_type = get_return_type(callback_return_args)
+
+                        py_type = f"{self.get_import('collections.abc', 'Callable')}[[{
+                            ', '.join(callback_args.values())
+                        }], {callback_return_type}]"
                 elif (
                     isinstance(interface_info, GI.EnumInfo)
                     and interface_info.get_g_type() != GObject.TYPE_NONE
@@ -810,7 +934,7 @@ class Stub:
     #         unpack_symbol = self.get_import("typing", "Unpack")
     #         annotation = re.sub(
     #             r"""['"]_DataTs['"]""",
-    #             f"{unpack_symbol}[_DataTs]",
+    #             self.get_unpack_data_ts(),
     #             annotation,
     #         )
     #
@@ -833,9 +957,14 @@ class Stub:
         name: str,
         function: GI.FunctionInfo | GI.VFuncInfo,
         in_class: type[Any] | None,
+        *,
         return_signature: str | None = None,
         comment: str | None = None,
+        mode: _FunctionMode = "sync",
+        finish_func: GI.FunctionInfo | None = None,
     ) -> str:
+        lines: list[str] = []
+
         constructor: bool = False
         method: bool = isinstance(function, GI.VFuncInfo)
         static: bool = False
@@ -852,18 +981,36 @@ class Stub:
         if in_class and not method and not constructor:
             static = True
 
+        if mode != "sync":
+            lines.append(f"@{self.get_import('typing', 'overload')}")
+
         # Arguments
-        args, return_args = self.get_callable_arguments(function)
+        if mode == "awaitable":
+            assert finish_func is not None
+            # awaitable
+            _, finish_return_args = self.get_callable_arguments(finish_func)
+            args, return_args = self.get_callable_arguments(
+                function, allow_varargs=False, mode=mode
+            )
+            return_type = f"{self.get_namespace_member('_gi', 'Async')}[{
+                get_return_type(finish_return_args)
+            }]"
+        else:
+            if mode in {"async_callback", "async_callback_kwargs"}:
+                args, return_args = self.get_callable_arguments(function, mode=mode)
+            else:
+                args, return_args = self.get_callable_arguments(function)
+
+            return_type = (
+                return_signature if return_signature else get_return_type(return_args)
+            )
+
         args_types = [
-            f"{self.fix_argument_name(name)}: {arg}" for name, arg in args.items()
+            name if name == "*" else f"{self.fix_argument_name(name)}: {arg}"
+            for name, arg in args.items()
         ]
 
-        return_type = (
-            return_signature if return_signature else get_return_type(return_args)
-        )
-
         # Generate string
-        prepend = ""
         if constructor:
             if name == "__init__":
                 # We pass the "new" constructor with the name __init__ because type
@@ -872,7 +1019,7 @@ class Stub:
                 args_types.insert(0, "self")
                 return_type = "None"
             else:
-                prepend = "@classmethod\n"
+                lines.append("@classmethod")
                 args_types.insert(0, "cls")
                 # Override return value, for example Gtk.Button.new returns a Gtk.Widget
                 # instead of Gtk.Button
@@ -882,16 +1029,16 @@ class Stub:
         elif method:
             args_types.insert(0, "self")
         elif static:
-            prepend = "@staticmethod\n"
+            lines.append("@staticmethod")
+
+        lines.append(
+            f"def {name}({', '.join(str(a) for a in args_types)}) -> {return_type}: ..."
+        )
 
         if comment:
-            return f"{prepend}def {name}({', '.join(str(a) for a in args_types)}) -> {
-                return_type
-            }: ... # {comment}\n"
+            lines[-1] += f" # {comment}"
 
-        return f"{prepend}def {name}({', '.join(str(a) for a in args_types)}) -> {
-            return_type
-        }: ...\n"
+        return "\n".join(lines) + "\n"
 
     def __wrapped_strip_boolean_result(
         self,
@@ -926,8 +1073,8 @@ class Stub:
             name,
             real_function,
             in_class,
-            return_signature,
-            "CHECK Wrapped function",
+            return_signature=return_signature,
+            comment="CHECK Wrapped function",
         )
 
     def build_function(
@@ -950,10 +1097,36 @@ class Stub:
             if in_class is None and function.get_namespace() != self.namespace:
                 # Set up a constant for functions that are aliases
                 return f"{name}: {self.get_final()} = {
-                    self.get_namespace_member(
-                        function.get_namespace(), f'{function.get_name()}'
-                    )
+                    self.get_namespace_member(function)
                 }\n"
+
+            if isinstance(function, GI.FunctionInfo):
+                finish_func = get_finish_func(function)
+
+                if finish_func is not None and not (
+                    function.get_flags() & GI.FunctionInfoFlags.IS_CONSTRUCTOR
+                ):
+                    return (
+                        self.__build_function(
+                            name,
+                            function,
+                            in_class,
+                            mode="awaitable",
+                            finish_func=finish_func,
+                        )
+                        + self.__build_function(
+                            name,
+                            function,
+                            in_class,
+                            mode="async_callback",
+                        )
+                        + self.__build_function(
+                            name,
+                            function,
+                            in_class,
+                            mode="async_callback_kwargs",
+                        )
+                    )
 
             return self.__build_function(name, function, in_class)
 
@@ -1293,6 +1466,23 @@ class Stub:
         # TODO: enable this when PyGObject exposes CallbackInfos
         # This must be called before generating the imports
         # callbacks = self.__build_callback_types()
+
+        if self.namespace == "Gio":
+            type_alias = self.get_import("typing", "TypeAlias")
+            callable_symbol = self.get_import("collections.abc", "Callable")
+            unpack_data_ts_symbol = self.get_unpack_data_ts()
+            gobject_protocol_symbol = self.get_namespace_member(
+                "GObject", "ObjectProtocol"
+            )
+            source_typevar_symbol = self.get_typevar(
+                "_SourceObjectT", bound=f"{gobject_protocol_symbol} | None"
+            )
+            async_result_symbol = self.get_namespace_member("Gio", "AsyncResult")
+            extras.append(
+                f"AsyncReadyCallback: {type_alias} = {callable_symbol}[[{
+                    source_typevar_symbol
+                }, {async_result_symbol}, {unpack_data_ts_symbol}], None]"
+            )
 
         imports = [f"{_import}" for _import in self.needed_imports.values()]
         extras_str = "\n".join(extras)

--- a/src/pygobject_stub_generator/utils.py
+++ b/src/pygobject_stub_generator/utils.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+from typing import cast
 from typing import Final
+from typing import Literal
+from typing import overload
+from typing import TYPE_CHECKING
+from typing import TypeAlias
+from typing_extensions import TypeVar
+
+from collections.abc import Callable
+from functools import wraps
 
 from gi import _gi as GI
+
+_T = TypeVar("_T")
 
 
 def make_nullable(type_str: str) -> str:
@@ -61,3 +72,108 @@ def is_ref_type(type_info: GI.TypeInfo, /) -> bool:
         return not isinstance(type_info.get_interface(), GI.EnumInfo)
 
     return True
+
+
+if TYPE_CHECKING:
+    import enum
+
+    class _MISSING_TYPE(enum.Enum):
+        MISSING = enum.auto()
+
+        def __eq__(self, other: object) -> Literal[False]: ...
+
+        def __bool__(self) -> Literal[False]: ...
+
+        def __hash__(self) -> int: ...
+
+        def __repr__(self) -> str: ...
+
+    MissingType: TypeAlias = Literal[_MISSING_TYPE.MISSING]
+    MISSING: Final = _MISSING_TYPE.MISSING
+else:
+
+    class _MissingSentinel:
+        __slots__ = ()
+
+        def __eq__(self, other: object) -> bool:
+            return False
+
+        def __bool__(self) -> Literal[False]:
+            return False
+
+        def __hash__(self) -> int:
+            return 0
+
+        def __repr__(self) -> str:
+            return "..."
+
+    MissingType: TypeAlias = _MissingSentinel
+    MISSING: Final[MissingType] = _MissingSentinel()
+
+
+def get_value(value: _T | MissingType, default: _T, /) -> _T:
+    return default if value is MISSING else value
+
+
+def get_finish_func(func: GI.FunctionInfo, /) -> GI.FunctionInfo | None:
+    try:
+        finish_func = func.get_finish_func()
+    except Exception:
+        # This can be triggered when functions like `g_set_prgname_once`
+        # are defined in the typelib but aren't in the library
+        finish_func = None
+
+    return finish_func
+
+
+_SelfT = TypeVar("_SelfT")
+_ReturnT = TypeVar("_ReturnT")
+_GetterT: TypeAlias = Callable[[_SelfT], _ReturnT]
+
+
+@overload
+def cache_slot(func: _GetterT[_SelfT, _ReturnT], /) -> _GetterT[_SelfT, _ReturnT]: ...
+
+
+@overload
+def cache_slot(
+    *,
+    slot_name: str | None = None,
+    default: object | None = None,
+) -> Callable[[_GetterT[_SelfT, _ReturnT]], _GetterT[_SelfT, _ReturnT]]: ...
+
+
+def cache_slot(
+    func: _GetterT[_SelfT, _ReturnT] | None = None,
+    /,
+    slot_name: str | None = None,
+    default: object | None = None,
+) -> (
+    _GetterT[_SelfT, _ReturnT]
+    | Callable[[_GetterT[_SelfT, _ReturnT]], _GetterT[_SelfT, _ReturnT]]
+):
+    def wrap(func: _GetterT[_SelfT, _ReturnT]) -> _GetterT[_SelfT, _ReturnT]:
+        _slot_name = f"_{func.__name__}" if slot_name is None else slot_name
+
+        @wraps(func)
+        def wrapper(self: _SelfT) -> _ReturnT:
+            value = getattr(self, _slot_name, default)
+            if value is not default:
+                return cast("_ReturnT", value)
+
+            value = func(self)
+
+            try:
+                setattr(self, _slot_name, value)
+            except AttributeError:
+                # use object.__setattr__ to bypass frozen dataclass's __setattr
+                object.__setattr__(self, _slot_name, value)
+
+            return value
+
+        return wrapper
+
+    if func is None:
+        return wrap
+
+    return wrap(func)


### PR DESCRIPTION
- Detect callable methods that have a paired `*_finish` function and emit three `@overload` variants for each: an awaitable form returning `_gi.Async[...]`, a keyword-only callback form, and a positional callback form with `*user_data`.
- Add `Arguments.as_async` / `as_async_callback_kwargs` to derive the visible argument set for each overload, and synthesize a `Gio.AsyncReadyCallback` type alias parameterized by the source object type.
- Add helpers to the `utils.py` module: a `MISSING` sentinel, `get_finish_func`, and a `cache_slot` decorator that lazily populates dataclass slots (works for frozen dataclasses via `object.__setattr__`).
- Refactor `class_info.py` and `stub.py` to use these helpers, and extend `get_namespace_member` to accept a `BaseInfo`.

Fixes #220
Fixes #302