### PR TITLE
cfix: GLib io_add_watch typo + QoL

### DIFF
--- a/src/gi-stubs/repository/GLib.pyi
+++ b/src/gi-stubs/repository/GLib.pyi
@@ -736,9 +736,9 @@ def intern_string(string: str | None = None) -> str: ...
 
 # override
 def io_add_watch(
-    channel: IOChannel,
+    channel: IOChannel | int,
     priority: int,
-    condition: IOChannel,
+    condition: IOCondition,
     func: Callable[[IOChannel, IOCondition, Unpack[_DataTs]], bool],
     *user_data: Unpack[_DataTs],
 ) -> int:


### PR DESCRIPTION
Fix a typo + allow `channel` to be `int`, which pygobject supports. Sorry for missing the typo. 

Turns out it that it's really nice to not have to wrap a file number in `GLib.IOChannel.unix_new()` when [pygobject will do it for you](https://gitlab.gnome.org/GNOME/pygobject/-/blob/main/gi/overrides/GLib.py?ref_type=heads#L830).